### PR TITLE
Update Notice to include relevant parts from FlexSDK NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -3,3 +3,10 @@ Copyright 2012-2017 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+The Initial Developer of the Original Code, known as Adobe Flex, is Adobe
+Systems Incorporated (http://www.adobe.com/).
+    Copyright 2003 - 2012 Adobe Systems Incorporated. All Rights Reserved.


### PR DESCRIPTION
As FlexSDK is ALv2 relevant bits in it's notice file need to be propagated to this notice file. See [1]
1. http://www.apache.org/dev/licensing-howto.html#alv2-dep