### PR TITLE
Only dispatch change event if new date is selected. Fixes #24 and partial fix for #23.

### DIFF
--- a/frameworks/projects/Basic/src/main/flex/org/apache/flex/html/beads/controllers/DateChooserMouseController.as
+++ b/frameworks/projects/Basic/src/main/flex/org/apache/flex/html/beads/controllers/DateChooserMouseController.as
@@ -80,8 +80,11 @@ package org.apache.flex.html.beads.controllers
         {
             var list:DateChooserList = event.target as DateChooserList;
             var model:DateChooserModel = _strand.getBeadByType(IBeadModel) as DateChooserModel;                     
-            model.selectedDate = list.selectedItem as Date;
-            IEventDispatcher(_strand).dispatchEvent( new Event("change") );
+	    var newDate:Date  = list.selectedItem as Date;
+	    if (newDate != null && model.selectedDate != newDate) {
+		model.selectedDate = newDate;
+		IEventDispatcher(_strand).dispatchEvent( new Event("change") );
+	    }
         }
 
 		/**


### PR DESCRIPTION
Stops potential RTE in client code when clicking on empty date cell and stops change event being dispatched if the same date is clicked on twice.