### PR TITLE
Adjust alert title bar size so that it doesn't go over it's RHS border

### DIFF
--- a/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/Alert.as
+++ b/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/Alert.as
@@ -127,7 +127,7 @@ package org.apache.royale.html
             titleBar = new TitleBar();
             addElement(titleBar);
             titleBar.element.id = 'titleBar';
-            titleBar.percentWidth = 100;
+            titleBar.percentWidth = 98; // so doesn't go over RHS border
             titleBar.height = 24;
             titleBar.element.style.top = "0px";
             titleBar.element.style.right = "0px";
@@ -147,7 +147,7 @@ package org.apache.royale.html
             
             // add a place for the buttons
             buttonArea = new Container();
-            buttonArea.percentWidth = 100;
+            buttonArea.percentWidth = 98; // so doesn't go over RHS border
             buttonArea.height = 28;
             addElement(buttonArea);
             buttonArea.element.style.marginTop = "6px";

--- a/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/beads/AlertView.as
+++ b/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/beads/AlertView.as
@@ -155,12 +155,12 @@ package org.apache.royale.html.beads
 			var titleMeasure:IMeasurementBead = _titleBar.measurementBead;
 			var ctrlMeasure:IMeasurementBead  = _controlBar.measurementBead;
 			var maxWidth:Number = Math.max(titleMeasure.measuredWidth, ctrlMeasure.measuredWidth, labelMeasure.measuredWidth);
-			
+			var border:Rectangle = CSSContainerUtils.getBorderMetrics(_strand);
 			var metrics:Rectangle = CSSContainerUtils.getBorderAndPaddingMetrics(_strand);
 
-			_titleBar.x = 0;
-			_titleBar.y = 0;
-			_titleBar.width = maxWidth;
+			_titleBar.x = border.left;
+			_titleBar.y = border.top;
+			_titleBar.width = maxWidth - border.left - border.right;
 			_titleBar.height = 25;
 			_titleBar.dispatchEvent(new Event("layoutNeeded"));
 			


### PR DESCRIPTION
The 98% is correct as the width is hardcoded to 200 pixels wide. If the width was to change then the percentages also also need to change.