### PR TITLE
Using thumb width in calculations causes thumb to jump right

### DIFF
--- a/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/beads/controllers/HSliderMouseController.as
+++ b/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/beads/controllers/HSliderMouseController.as
@@ -295,9 +295,7 @@ package org.apache.royale.html.beads.controllers
         private function calcValFromMousePosition(event:BrowserEvent, useOffset:Boolean):void
         {
             var deltaX:Number = (useOffset ? event.offsetX : event.clientX) - mouseOrigin;
-            var thumbW:int = parseInt(thumb.element.style.width, 10) / 2;
-            var newX:Number = thumbOrigin + deltaX;
-			var newPointX:Number = newX + thumbW; // center of the thumb which represents the value
+            var newPointX:Number = thumbOrigin + deltaX;	
 			
 			var useWidth:Number = parseInt(track.element.style.width,10) * 1.0;
 			var p:Number = newPointX / useWidth;

--- a/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/beads/controllers/VSliderMouseController.as
+++ b/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/beads/controllers/VSliderMouseController.as
@@ -279,9 +279,7 @@ package org.apache.royale.html.beads.controllers
 		private function calcValFromMousePosition(event:BrowserEvent, useOffset:Boolean):void
 		{
 			var deltaY:Number = (useOffset ? event.offsetY : event.clientY) - mouseOrigin;
-			var thumbH:int = parseInt(thumb.element.style.height, 10) / 2;
-			var newY:Number = thumbOrigin + deltaY;
-			var newPointY:Number = newY + thumbH; // center of the thumb which represents the value
+			var newPointY:Number = thumbOrigin + deltaY;
 			
 			var useHeight:Number = parseInt(track.element.style.height,10) * 1.0;
 			var p:Number = newPointY / useHeight;


### PR DESCRIPTION
When clicking on the thumb half the thumb width is added to the thumb for a simple click on a thumb (with no drag) the thumb should stay where it is.