### PR TITLE
Completing MX logging functionality as per Flex behaviour

### DIFF
--- a/frameworks/projects/MXRoyale/src/main/royale/MXRoyaleClasses.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/MXRoyaleClasses.as
@@ -84,8 +84,6 @@ internal class MXRoyaleClasses
 	import mx.charts.chartClasses.DataTransform; DataTransform;
 	import mx.skins.Border; Border;
 	import mx.effects.CompositeEffect; CompositeEffect;
-	import mx.logging.LogEventLevel; LogEventLevel;
-	import mx.logging.ILogger; ILogger;
 	import mx.core.FlexVersion; FlexVersion;
 	import mx.charts.chartClasses.CartesianTransform; CartesianTransform;
 	import mx.charts.events.ChartItemEvent; ChartItemEvent;
@@ -93,6 +91,15 @@ internal class MXRoyaleClasses
   	import mx.controls.textClasses.TextRange; TextRange;
 	import mx.managers.CursorManagerPriority; CursorManagerPriority;
 	import mx.logging.Log; Log;
+	import mx.logging.LogLogger; LogLogger;
+	import mx.logging.LogEvent; LogEvent;
+	import mx.logging.LogEventLevel; LogEventLevel;
+	import mx.logging.AbstractTarget; AbstractTarget;
+	import mx.logging.ILogger; ILogger;
+	import mx.logging.ILoggingTarget; ILoggingTarget;
+	import mx.logging.errors.InvalidFilterError; InvalidFilterError;
+	import mx.logging.targets.LineFormattedTarget; LineFormattedTarget;
+	import mx.logging.targets.TraceTarget; TraceTarget;
 	import mx.charts.chartClasses.Series; Series;
 	import mx.charts.chartClasses.GraphicsUtilities; GraphicsUtilities; 
 	import mx.effects.easing.Bounce; Bounce;

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/logging/AbstractTarget.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/logging/AbstractTarget.as
@@ -1,0 +1,393 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package mx.logging
+{
+
+import mx.logging.errors.InvalidFilterError;
+import mx.managers.ISystemManager;
+import mx.managers.SystemManager;
+import mx.resources.IResourceManager;
+import mx.resources.ResourceManager;
+import org.apache.royale.utils.UIDUtil;
+
+//[ResourceBundle("logging")]
+
+/**
+ *  This class provides the basic functionality required by the logging framework 
+ *  for a target implementation.
+ *  It handles the validation of filter expressions and provides a default level 
+ *  property.
+ *  No implementation of the <code>logEvent()</code> method is provided.
+ *  
+ *  @langversion 3.0
+ *  @playerversion Flash 9
+ *  @playerversion AIR 1.1
+ *  @productversion Flex 3
+ */
+public class AbstractTarget implements ILoggingTarget
+{
+//    include "../core/Version.as";
+
+    //--------------------------------------------------------------------------
+    //
+    //  Constructor
+    //
+    //--------------------------------------------------------------------------
+
+    /**
+     *  Constructor.
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Flex 3
+     */
+    public function AbstractTarget()
+    {
+        super();
+
+        _id = org.apache.royale.utils.UIDUtil.createUID();
+    }
+
+    //--------------------------------------------------------------------------
+    //
+    //  Variables
+    //
+    //--------------------------------------------------------------------------
+
+    /**
+     *  @private
+     *  Count of the number of loggers this target is listening to. When this
+     *  value is zero changes to the filters property shouldn't do anything
+     */
+    private var _loggerCount:uint = 0;
+
+    /**
+     *  @private
+     *  Used for accessing localized Error messages.
+     */
+    private var resourceManager:IResourceManager =
+                                    ResourceManager.getInstance();
+
+    //--------------------------------------------------------------------------
+    //
+    //  Properties
+    //
+    //--------------------------------------------------------------------------
+
+    //----------------------------------
+    //  filters
+    //----------------------------------
+
+    /**
+     *  @private
+     *  Storage for the filters property.
+     */
+    private var _filters:Array = [ "*" ];
+
+    [Inspectable(category="General", arrayType="String")]
+    
+    /**
+     *  In addition to the <code>level</code> setting, filters are used to
+     *  provide a psuedo-hierarchical mapping for processing only those events
+     *  for a given category.
+     *  <p>
+     *  Each logger belongs to a category.
+     *  By convention these categories map to the fully-qualified class name in
+     *  which the logger is used.
+     *  For example, a logger that is logging messages for the
+     *  <code>mx.rpc.soap.WebService</code> class, uses 
+     *  "mx.rpc.soap.WebService" as the parameter to the 
+     *  <code>Log.getLogger()</code> method call.
+     *  When messages are sent under this category only those targets that have
+     *  a filter which matches that category receive notification of those
+     *  events.
+     *  Filter expressions can include a wildcard match, indicated with an
+     *  asterisk.
+     *  The wildcard must be the right-most character in the expression.
+     *  For example: rpc~~, mx.~~, or ~~.
+     *  If an invalid expression is specified, a <code>InvalidFilterError</code>
+     *  is thrown.
+     *  If <code>null</code> or [] is specified, the filters are set to the
+     *  default of ["~~"].
+     *  </p>
+     *  <p>For example:
+     *     <pre>
+     *           var traceLogger:ILoggingTarget = new TraceTarget();
+     *           traceLogger.filters = ["mx.rpc.~~", "mx.messaging.~~"];
+     *           Log.addTarget(traceLogger);
+     *     </pre>
+     *  </p>
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Flex 3
+     */
+    public function get filters():Array
+    {
+        return _filters;
+    }
+
+    /**
+     *  @private
+     *  This method will make sure that all of the filter expressions specified
+     *  are valid, and will throw <code>InvalidFilterError</code> if any are not.
+     */
+    public function set filters(value:Array):void
+    {
+        if (value && value.length > 0)
+        {
+            // a valid filter value will be fully qualified or have a wildcard
+            // in it.  the wild card can only be located at the end of the
+            // expression.  valid examples  xx*, xx.*,  *
+            var filter:String;
+            var index:int;
+            var message:String;
+            for (var i:uint = 0; i<value.length; i++)
+            {
+                filter = value[i];
+                  // check for invalid characters
+                if (Log.hasIllegalCharacters(filter))
+                {
+                    message = resourceManager.getString(
+                        "logging", "charsInvalid", [ filter ]);
+                    throw new InvalidFilterError(message);
+                }
+
+                index = filter.indexOf("*");
+                if ((index >= 0) && (index != (filter.length -1)))
+                {
+                    message = resourceManager.getString(
+                        "logging", "charPlacement", [ filter ]);
+                    throw new InvalidFilterError(message);
+                }
+            } // for
+        }
+        else
+        {
+            // if null was specified then default to all
+            value = ["*"];
+        }
+
+        if (_loggerCount > 0)
+        {
+            Log.removeTarget(this);
+            _filters = value;
+            Log.addTarget(this);
+        }
+        else
+        {
+            _filters = value;
+        }
+    }
+
+    //----------------------------------
+    //  id
+    //----------------------------------
+
+    /**
+     *  @prviate
+     *  Storage for the id property.
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Flex 3
+     */
+    private var _id:String;
+
+    [Inspectable(category="General")]
+
+     /**
+      *  Provides access to the id of this target.
+      *  The id is assigned at runtime by the mxml compiler if used as an mxml 
+      *  tag, or internally if used within a script block
+      *  
+      *  @langversion 3.0
+      *  @playerversion Flash 9
+      *  @playerversion AIR 1.1
+      *  @productversion Flex 3
+      */
+     public function get id():String
+     {
+         return _id;
+     }
+    
+    //----------------------------------
+    //  level
+    //----------------------------------
+
+    /**
+     *  @private
+     *  Storage for the level property.
+     */
+    private var _level:int = LogEventLevel.ALL;
+
+    /**
+     *  Provides access to the level this target is currently set at.
+     *  Value values are:
+     *    <ul>
+     *      <li><code>LogEventLevel.FATAL (1000)</code> designates events that are very
+     *      harmful and will eventually lead to application failure</li>
+     *
+     *      <li><code>LogEventLevel.ERROR (8)</code> designates error events that might
+     *      still allow the application to continue running.</li>
+     *
+     *      <li><code>LogEventLevel.WARN (6)</code> designates events that could be
+     *      harmful to the application operation</li>
+     *
+     *      <li><code>LogEventLevel.INFO (4)</code> designates informational messages
+     *      that highlight the progress of the application at
+     *      coarse-grained level.</li>
+     *
+     *      <li><code>LogEventLevel.DEBUG (2)</code> designates informational
+     *      level messages that are fine grained and most helpful when
+     *      debugging an application.</li>
+     *
+     *      <li><code>LogEventLevel.ALL (0)</code> intended to force a target to
+     *      process all messages.</li>
+     *    </ul>
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Flex 3
+     */
+    public function get level():int
+    {
+        return _level;
+    }
+
+    /**
+     *  @private
+     */
+    public function set level(value:int):void
+    {
+        // A change of level may impact the target level for Log.
+        Log.removeTarget(this);
+        _level = value;
+        Log.addTarget(this);        
+    }
+
+    //--------------------------------------------------------------------------
+    //
+    //  Methods
+    //
+    //--------------------------------------------------------------------------
+
+    /**
+     *  Sets up this target with the specified logger.
+     *  This allows this target to receive log events from the specified logger.
+     *
+     *  @param logger The ILogger that this target should listen to.
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Flex 3
+     */
+    public function addLogger(logger:ILogger):void
+    {
+        if (logger)
+        {
+            _loggerCount++;
+            logger.addEventListener(LogEvent.LOG, logHandler);
+        }
+    }
+
+    /**
+     *  Stops this target from receiving events from the specified logger.
+     *
+     *  @param logger The ILogger that this target should ignore.
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Flex 3
+     */
+    public function removeLogger(logger:ILogger):void
+    {
+        if (logger)
+        {
+            _loggerCount--;
+            logger.removeEventListener(LogEvent.LOG, logHandler);
+        }
+    }
+
+    /**
+     *  Called after the implementing object has been created
+     *  and all properties specified on the tag have been assigned.
+     *
+     *  @param document MXML document that created this object.
+     *
+     *  @param id Used by the document to refer to this object.
+     *  If the object is a deep property on the document, id is null.
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Flex 3
+     */
+    public function initialized(document:Object, id:String):void
+    {
+        _id = id;
+        Log.addTarget(this);
+    }
+
+    /**
+     *  This method handles a <code>LogEvent</code> from an associated logger.
+     *  A target uses this method to translate the event into the appropriate
+     *  format for transmission, storage, or display.
+     *  This method will be called only if the event's level is in range of the
+     *  target's level.
+     *
+     *  <p><b><i>NOTE: Descendants must override this method to make it useful.</i></b></p>
+     *  
+     *  @param event An event from an associated logger.
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Flex 3
+     */
+    public function logEvent(event:LogEvent):void
+    {
+    }
+
+    //--------------------------------------------------------------------------
+    //
+    //  Event handlers
+    //
+    //--------------------------------------------------------------------------
+
+    /**
+     *  @private
+     *  This method will call the <code>logEvent</code> method if the level of the
+     *  event is appropriate for the current level.
+     */
+    private function logHandler(event:LogEvent):void
+    {
+        if (event.level >= level)
+            logEvent(event);
+    }
+}
+
+}

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/logging/errors/InvalidFilterError.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/logging/errors/InvalidFilterError.as
@@ -1,0 +1,84 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package mx.logging.errors
+{
+
+/**
+ *  This error is thrown when a filter specified for a target
+ *  contains invalid characters or is malformed.
+ *  This error is thrown by the following methods/properties:
+ *  <ul>
+ *    <li><code>ILoggerTarget.filters</code> if a filter expression
+ *    in this listis malformed.</li>
+ *  </ul>
+ *  
+ *  @langversion 3.0
+ *  @playerversion Flash 9
+ *  @playerversion AIR 1.1
+ *  @productversion Flex 3
+ */
+public class InvalidFilterError extends Error
+{
+//	include "../../core/Version.as";
+
+	//--------------------------------------------------------------------------
+	//
+	//  Constructor
+	//
+	//--------------------------------------------------------------------------
+
+    /**
+	 *  Constructor.
+	 *
+	 *  @param message The message that describes this error.
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Flex 3
+     */
+    public function InvalidFilterError(message:String)
+    {
+        super(message);
+    }
+
+	//--------------------------------------------------------------------------
+	//
+	//  Methods
+	//
+	//--------------------------------------------------------------------------
+
+         /**
+	 *  Returns the messge as a String.
+	 *  
+	 *  @return The message.
+	 *  
+	 *  @langversion 3.0
+	 *  @playerversion Flash 9
+	 *  @playerversion AIR 1.1
+	 *  @productversion Flex 3
+	 */
+    public function toString():String
+    {
+        return String(message);
+    }
+}
+
+}

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/logging/targets/LineFormattedTarget.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/logging/targets/LineFormattedTarget.as
@@ -1,0 +1,258 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package mx.logging.targets
+{
+
+import mx.logging.AbstractTarget;
+import mx.logging.ILogger;
+import mx.logging.LogEvent;
+
+
+/**
+ *  All logger target implementations that have a formatted line style output
+ *  should extend this class.
+ *  It provides default behavior for including date, time, category, and level
+ *  within the output.
+ *
+ *  
+ *  @langversion 3.0
+ *  @playerversion Flash 9
+ *  @playerversion AIR 1.1
+ *  @productversion Flex 3
+ */
+public class LineFormattedTarget extends AbstractTarget
+{
+//    include "../../core/Version.as";
+
+    //--------------------------------------------------------------------------
+    //
+    //  Constructor
+    //
+    //--------------------------------------------------------------------------
+
+    /**
+     *  Constructor.
+     *
+     *  <p>Constructs an instance of a logger target that will format
+     *  the message data on a single line.</p>
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Flex 3
+     */
+    public function LineFormattedTarget()
+    {
+        super();
+
+        includeTime = false;
+        includeDate = false;
+        includeCategory = false;
+        includeLevel = false;
+    }
+
+    //--------------------------------------------------------------------------
+    //
+    //  Properties
+    //
+    //--------------------------------------------------------------------------
+
+    //----------------------------------
+    //  fieldSeparator
+    //----------------------------------
+
+    [Inspectable(category="General", defaultValue=" ")]
+    
+    /**
+     *  The separator string to use between fields (the default is " ")
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Flex 3
+     */
+    public var fieldSeparator:String = " ";
+
+    //----------------------------------
+    //  includeCategory
+    //----------------------------------
+
+    [Inspectable(category="General", defaultValue="false")]
+    
+    /**
+     *  Indicates if the category for this target should added to the trace.
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Flex 3
+     */
+    public var includeCategory:Boolean;
+
+    //----------------------------------
+    //  includeDate
+    //----------------------------------
+
+    [Inspectable(category="General", defaultValue="false")]
+    
+    /**
+     *  Indicates if the date should be added to the trace.
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Flex 3
+     */
+    public var includeDate:Boolean;
+
+    //----------------------------------
+    //  includeLevel
+    //----------------------------------
+
+    [Inspectable(category="General", defaultValue="false")]
+    
+    /**
+     *  Indicates if the level for the event should added to the trace.
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Flex 3
+     */
+    public var includeLevel:Boolean;
+
+    //----------------------------------
+    //  includeTime
+    //----------------------------------
+
+    [Inspectable(category="General", defaultValue="false")]
+    
+    /**
+     *  Indicates if the time should be added to the trace.
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Flex 3
+     */
+    public var includeTime:Boolean;
+
+    //--------------------------------------------------------------------------
+    //
+    //  Overridden methods
+    //
+    //--------------------------------------------------------------------------
+
+    /**
+     *  This method handles a <code>LogEvent</code> from an associated logger.
+     *  A target uses this method to translate the event into the appropriate
+     *  format for transmission, storage, or display.
+     *  This method is called only if the event's level is in range of the
+     *  target's level.
+     * 
+     *  @param event The <code>LogEvent</code> handled by this method.
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Flex 3
+     */
+    override public function logEvent(event:LogEvent):void
+    {
+        var date:String = "";
+        if (includeDate || includeTime)
+        {
+            var d:Date = new Date();
+            if (includeDate)
+            {
+                date = Number(d.getMonth() + 1).toString() + "/" +
+                       d.getDate().toString() + "/" + 
+                       d.getFullYear() + fieldSeparator;
+            }   
+            if (includeTime)
+            {
+                date += padTime(d.getHours()) + ":" +
+                        padTime(d.getMinutes()) + ":" +
+                        padTime(d.getSeconds()) + "." +
+                        padTime(d.getMilliseconds(), true) + fieldSeparator;
+            }
+        }
+        
+        var level:String = "";
+        if (includeLevel)
+        {
+            level = "[" + LogEvent.getLevelString(event.level) +
+                    "]" + fieldSeparator;
+        }
+
+        var category:String = includeCategory ?
+                              ILogger(event.target).category + fieldSeparator :
+                              "";
+
+        internalLog(date + level + category + event.message);
+    }
+    
+    //--------------------------------------------------------------------------
+    //
+    //  Methods
+    //
+    //--------------------------------------------------------------------------
+
+    /**
+     *  @private
+     */
+    private function padTime(num:Number, millis:Boolean = false):String
+    {
+        if (millis)
+        {
+            if (num < 10)
+                return "00" + num.toString();
+            else if (num < 100)
+                return "0" + num.toString();
+            else 
+                return num.toString();
+        }
+        else
+        {
+            return num > 9 ? num.toString() : "0" + num.toString();
+        }
+    }
+
+    /**
+     *  Descendants of this class should override this method to direct the 
+     *  specified message to the desired output.
+     *
+     *  @param  message String containing preprocessed log message which may
+     *              include time, date, category, etc. based on property settings,
+     *              such as <code>includeDate</code>, <code>includeCategory</code>,
+     *          etc.
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Flex 3
+     */
+    protected function internalLog(message:String):void
+    {
+        // override this method to perform the redirection to the desired output
+    }
+}
+
+}

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/logging/targets/TraceTarget.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/logging/targets/TraceTarget.as
@@ -20,10 +20,8 @@
 package mx.logging.targets
 {
 
-import mx.core.mx_internal;
 import mx.logging.LogEventLevel;
 import mx.logging.ILogger;
-use namespace mx_internal;
 
 /**
  *  Provides a logger target that uses the global <code>trace()</code> method to output log messages.
@@ -42,9 +40,9 @@ use namespace mx_internal;
  *  @productversion Royale 0.9.3
  *  @royalesuppresspublicvarwarning
  */
-public class TraceTarget 
+public class TraceTarget extends LineFormattedTarget
 {
-/* extends LineFormattedTarget */
+/*  */
  //   include "../../core/Version.as";
 
     //--------------------------------------------------------------------------
@@ -67,246 +65,25 @@ public class TraceTarget
      */
     public function TraceTarget()
     {
-		//super();
-		
-		
-		
+		super();
     }
 
-   
-    //----------------------------------
-    //  includeLevel copied from LineFormattedTarget
-    //----------------------------------
-
-    [Inspectable(category="General", defaultValue="false")]
-    
     /**
-     *  Indicates if the level for the event should added to the trace.
+     *  Implementation to log the message via the <code>trace()</code> method.
+     *
+     *  @param  message String containing preprocessed log message which may
+     *              include time, date, category, etc. based on property settings,
+     *              such as <code>includeDate</code>, <code>includeCategory</code>,
+     *          etc.
      *  
      *  @langversion 3.0
      *  @playerversion Flash 9
      *  @playerversion AIR 1.1
-     *  @productversion Royale 0.9.3
+     *  @productversion Flex 3
      */
-    public var includeLevel:Boolean;
-
-	 //----------------------------------
-    //  includeTime copied from LineFormattedTarget
-    //----------------------------------
-
-    [Inspectable(category="General", defaultValue="false")]
-    
-    /**
-     *  Indicates if the time should be added to the trace.
-     *  
-     *  @langversion 3.0
-     *  @playerversion Flash 9
-     *  @playerversion AIR 1.1
-     *  @productversion Royale 0.9.3
-     */
-    public var includeTime:Boolean;
-
-	 //----------------------------------
-    //  filters copied from AbstractTarget
-    //----------------------------------
-
-    /**
-     *  @private
-     *  Storage for the filters property.
-     */
-    private var _filters:Array = [ "*" ];
-
-    [Inspectable(category="General", arrayType="String")]
-    
-    /**
-     *  In addition to the <code>level</code> setting, filters are used to
-     *  provide a psuedo-hierarchical mapping for processing only those events
-     *  for a given category.
-     *  <p>
-     *  Each logger belongs to a category.
-     *  By convention these categories map to the fully-qualified class name in
-     *  which the logger is used.
-     *  For example, a logger that is logging messages for the
-     *  <code>mx.rpc.soap.WebService</code> class, uses 
-     *  "mx.rpc.soap.WebService" as the parameter to the 
-     *  <code>Log.getLogger()</code> method call.
-     *  When messages are sent under this category only those targets that have
-     *  a filter which matches that category receive notification of those
-     *  events.
-     *  Filter expressions can include a wildcard match, indicated with an
-     *  asterisk.
-     *  The wildcard must be the right-most character in the expression.
-     *  For example: rpc~~, mx.~~, or ~~.
-     *  If an invalid expression is specified, a <code>InvalidFilterError</code>
-     *  is thrown.
-     *  If <code>null</code> or [] is specified, the filters are set to the
-     *  default of ["~~"].
-     *  </p>
-     *  <p>For example:
-     *     <pre>
-     *           var traceLogger:ILoggingTarget = new TraceTarget();
-     *           traceLogger.filters = ["mx.rpc.~~", "mx.messaging.~~"];
-     *           Log.addTarget(traceLogger);
-     *     </pre>
-     *  </p>
-     *  
-     *  @langversion 3.0
-     *  @playerversion Flash 9
-     *  @playerversion AIR 1.1
-     *  @productversion Royale 0.9.3
-     */
-    public function get filters():Array
+    override protected function internalLog(message:String):void
     {
-        return _filters;
-    }
-
-    /**
-     *  @private
-     *  This method will make sure that all of the filter expressions specified
-     *  are valid, and will throw <code>InvalidFilterError</code> if any are not.
-     */
-    public function set filters(value:Array):void
-    {
-        /* if (value && value.length > 0)
-        {
-            // a valid filter value will be fully qualified or have a wildcard
-            // in it.  the wild card can only be located at the end of the
-            // expression.  valid examples  xx*, xx.*,  *
-            var filter:String;
-            var index:int;
-            var message:String;
-            for (var i:uint = 0; i<value.length; i++)
-            {
-                filter = value[i];
-                  // check for invalid characters
-                if (Log.hasIllegalCharacters(filter))
-                {
-                    message = resourceManager.getString(
-                        "logging", "charsInvalid", [ filter ]);
-                    throw new InvalidFilterError(message);
-                }
-
-                index = filter.indexOf("*");
-                if ((index >= 0) && (index != (filter.length -1)))
-                {
-                    message = resourceManager.getString(
-                        "logging", "charPlacement", [ filter ]);
-                    throw new InvalidFilterError(message);
-                }
-            } // for
-        }
-        else
-        {
-            // if null was specified then default to all
-            value = ["*"];
-        }
-
-        if (_loggerCount > 0)
-        {
-            Log.removeTarget(this);
-            _filters = value;
-            Log.addTarget(this);
-        }
-        else
-        {
-            _filters = value;
-        } */
-    }
-	//addLogger copied from AbstractTarget
-	/**
-     *  Sets up this target with the specified logger.
-     *  This allows this target to receive log events from the specified logger.
-     *
-     *  @param logger The ILogger that this target should listen to.
-     *  
-     *  @langversion 3.0
-     *  @playerversion Flash 9
-     *  @playerversion AIR 1.1
-     *  @productversion Royale 0.9.3
-     */
-    public function addLogger(logger:ILogger):void
-    {
-        if (logger)
-        {
-           // _loggerCount++;
-           // logger.addEventListener(LogEvent.LOG, logHandler);
-        }
-    }
-	
-	//removeLogger copied from AbstractTarget
-	/**
-     *  Stops this target from receiving events from the specified logger.
-     *
-     *  @param logger The ILogger that this target should ignore.
-     *  
-     *  @langversion 3.0
-     *  @playerversion Flash 9
-     *  @playerversion AIR 1.1
-     *  @productversion Royale 0.9.3
-     */
-    public function removeLogger(logger:ILogger):void
-    {
-        if (logger)
-        {
-          //  _loggerCount--;
-           // logger.removeEventListener(LogEvent.LOG, logHandler);
-        }
-    }
-	
-	 //----------------------------------
-    //  level
-    //----------------------------------
-
-    /**
-     *  @private
-     *  Storage for the level property.
-     */
-    private var _level:int = LogEventLevel.ALL;
-
-    /**
-     *  Provides access to the level this target is currently set at.
-     *  Value values are:
-     *    <ul>
-     *      <li><code>LogEventLevel.FATAL (1000)</code> designates events that are very
-     *      harmful and will eventually lead to application failure</li>
-     *
-     *      <li><code>LogEventLevel.ERROR (8)</code> designates error events that might
-     *      still allow the application to continue running.</li>
-     *
-     *      <li><code>LogEventLevel.WARN (6)</code> designates events that could be
-     *      harmful to the application operation</li>
-     *
-     *      <li><code>LogEventLevel.INFO (4)</code> designates informational messages
-     *      that highlight the progress of the application at
-     *      coarse-grained level.</li>
-     *
-     *      <li><code>LogEventLevel.DEBUG (2)</code> designates informational
-     *      level messages that are fine grained and most helpful when
-     *      debugging an application.</li>
-     *
-     *      <li><code>LogEventLevel.ALL (0)</code> intended to force a target to
-     *      process all messages.</li>
-     *    </ul>
-     *  
-     *  @langversion 3.0
-     *  @playerversion Flash 9
-     *  @playerversion AIR 1.1
-     *  @productversion Royale 0.9.3
-     */
-    public function get level():int
-    {
-        return _level;
-    }
-
-    /**
-     *  @private
-     */
-    public function set level(value:int):void
-    {
-        // A change of level may impact the target level for Log.
-       //Log.removeTarget(this);
-        _level = value;
-      //  Log.addTarget(this);        
+        trace(message);
     }
 	
 }


### PR DESCRIPTION
Adding the remaining classes from the Flex codebase so that we have AbstractTarget and LineFormattedTarget, from which TraceTarget can now derive.
Just simplifies any Flex migration by replicating these classes as-is.
Please let me know of any changes needed/suggestions etc..
thanks