### PR TITLE
URLLoader: HTTPStatusEvent addition

### DIFF
--- a/frameworks/projects/Network/src/main/royale/NetworkClasses.as
+++ b/frameworks/projects/Network/src/main/royale/NetworkClasses.as
@@ -32,6 +32,10 @@ package
         import org.apache.royale.net.URLBinaryUploader; URLBinaryUploader;
         import org.apache.royale.net.events.ResultEvent; ResultEvent;
         import org.apache.royale.net.events.FaultEvent; FaultEvent;
+        COMPILE::JS
+        {
+            import org.apache.royale.net.events.HTTPStatusEvent; HTTPStatusEvent;
+        }
         
         import org.apache.royale.net.remoting.messages.AcknowledgeMessage; AcknowledgeMessage;
         import org.apache.royale.net.remoting.messages.AcknowledgeMessageExt;

--- a/frameworks/projects/Network/src/main/royale/org/apache/royale/net/URLLoader.as
+++ b/frameworks/projects/Network/src/main/royale/org/apache/royale/net/URLLoader.as
@@ -74,6 +74,8 @@ package org.apache.royale.net
         COMPILE::JS
         private var element:XMLHttpRequest;
         
+        private var _statusCode:int = 0;
+        
         public function URLLoader()
         {
             super();
@@ -226,6 +228,7 @@ package org.apache.royale.net
             if ("responseURL" in event)
                 _responseURL = event.responseURL;
             */
+            _statusCode = event.status;
             dispatchEvent(new Event(event.type));
         }
         
@@ -264,6 +267,7 @@ package org.apache.royale.net
         protected function progressHandler():void
         {
             var element:XMLHttpRequest = this.element as XMLHttpRequest;
+            _statusCode = element.status;
             if (element.readyState == 2) {
                 dispatchEvent(HTTPConstants.RESPONSE_STATUS);
                 dispatchEvent(HTTPConstants.STATUS);
@@ -293,6 +297,13 @@ package org.apache.royale.net
             }
         }
         
+        /**
+         *  HTTP Status code. 0 means no status code has been received.
+         */
+        public function get statusCode():int
+        {
+            return _statusCode;
+        }
     }
 }
 

--- a/frameworks/projects/Network/src/main/royale/org/apache/royale/net/events/HTTPStatusEvent.as
+++ b/frameworks/projects/Network/src/main/royale/org/apache/royale/net/events/HTTPStatusEvent.as
@@ -1,0 +1,39 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+package org.apache.royale.net.events
+{
+	import org.apache.royale.events.Event;
+    import org.apache.royale.net.URLLoader;
+	
+    /**
+     *  HTTPStatusEvent is dispatched from a URLLoader
+     *  when it receives readyState = 2 with an HTTP
+     *  status code.
+     */
+	public class HTTPStatusEvent extends Event
+	{
+		public static const HTTP_STATUS:String = "httpStatus";
+		public var status:uint;
+		public function HTTPStatusEvent(statusCode:uint, bubbles:Boolean = false, cancelable:Boolean = true)
+		{
+			super(HTTP_STATUS, bubbles, cancelable);
+			status = statusCode;
+		}
+	}
+}


### PR DESCRIPTION
Adding an HTTPStatusEvent into the JS-based code. We've found that this is required by some applications and it seems to make sense to expose this to client code. Initial thought was to add a status property to the URLLoader directly, but the "httpStatus" event was already being dispatched, so this just adds an extra value to the event object so that listeners can check whether the request was successful.