### PR TITLE
Adding listener for when a bindable style has changed

### DIFF
--- a/frameworks/projects/Basic/src/main/royale/org/apache/royale/core/UIBase.as
+++ b/frameworks/projects/Basic/src/main/royale/org/apache/royale/core/UIBase.as
@@ -1416,6 +1416,10 @@ package org.apache.royale.core
                 
                 if (style)
                     ValuesManager.valuesImpl.applyStyles(this, style);
+
+                // add an event listener if the style dispatches events (e.g. BindableCSSStyles)
+                var styleAsEventDispatcher : IEventDispatcher = style as IEventDispatcher;
+                if (styleAsEventDispatcher) styleAsEventDispatcher.addEventListener(ValueChangeEvent.VALUE_CHANGE, styleChangeHandler);
             }
             
 			if (isNaN(_explicitWidth) && isNaN(_percentWidth)) 


### PR DESCRIPTION
There was already an event handler for this, but it wasn't being hooked up... If we have some bindable styles, they are being updated by the binding code but the style wasn't being re-applied to the element. Adding this event listener (if the style implements IEventDispatcher - the bindable one does, the simple one doesn't) made it all just work..
