### PR TITLE
Make JS nativeEvent public

### DIFF
--- a/frameworks/projects/Core/src/main/royale/org/apache/royale/events/KeyboardEvent.as
+++ b/frameworks/projects/Core/src/main/royale/org/apache/royale/events/KeyboardEvent.as
@@ -56,7 +56,7 @@ package org.apache.royale.events
 		 * @type {KeyboardEvent}
 		 */
         COMPILE::JS
-		private var nativeEvent:Object;
+		public var nativeEvent:Object;
 
         COMPILE::JS
 		public function wrapEvent(event:goog.events.BrowserEvent):void


### PR DESCRIPTION
The native JS event should be accessible to application developers.