### PR TITLE
Adding support for posting data

### DIFF
--- a/frameworks/projects/Network/src/main/royale/org/apache/royale/net/URLLoader.as
+++ b/frameworks/projects/Network/src/main/royale/org/apache/royale/net/URLLoader.as
@@ -192,21 +192,28 @@ package org.apache.royale.net
                     }
                 }
                 
-                /*
-                if (request.method != HTTPConstants.GET &&
-                    !sawContentType && contentData) {
-                    element.setRequestHeader(
-                        HTTPHeader.CONTENT_TYPE, _contentType);
+                var dataToSend : Object = null;
+
+                // if we are doing a post (or any non-GET) and we have data,
+                // then set this up; we also need to add the content type if it wasn't already set..
+                if ( (request.method != HTTPConstants.GET) && (request.data != null) )
+                {
+                    if (!sawContentType)
+                    {
+                        element.setRequestHeader(HTTPHeader.CONTENT_TYPE, request.contentType);
+                    }
+                    if (request.data is BinaryData)
+                    {
+                        dataToSend = request.data.array;
+                    }
+                    else if (request.data is String)
+                    {
+                        dataToSend = request.data;
+                    }
                 }
-                */
-                /*
-                if (contentData) {
-                    element.send(contentData);
-                } else {*/
-                    element.send();
-                /*
-                }
-                */
+
+                // send the request (data is null if no request body)
+                element.send(dataToSend);
             }
             
             dispatchEvent(new Event("postSend"));


### PR DESCRIPTION
Taking the information already present in the URLRequest object and setting it appropriately on the XMLHttpRequest within the URLLoader object

This then allows us to send a 'post' request with strings or with binarydata objects on a JavaScript build (it would already work on a SWF build due to the use of the flash.net.URLLoader object).