### PR TITLE
Updating ExternalInterface to cope with qnamed functions

### DIFF
--- a/frameworks/projects/MXRoyale/src/main/royale/mx/external/ExternalInterface.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/external/ExternalInterface.as
@@ -157,6 +157,7 @@ package mx.external
          *
          * @param functionName The name of the JavaScript function to call.
          * @param ... args The arguments to pass to the JavaScript function in the browser.
+         * @royaleignorecoercion Function
          */
         public static function call(functionName:String, ... args):*
         {
@@ -167,11 +168,19 @@ package mx.external
             }
             COMPILE::JS
             {
-                // find a function with the name...
-                var fnc : Function = window[functionName];
+                // find a function with the name... which may be in dot.notation
+                var arrFunctionName : Array = functionName.split(".");
+                var parentObj : Object = null;
+                var functionObj : Object = window;
+                while (functionObj && arrFunctionName.length)
+                {
+                    parentObj = functionObj;
+                    functionObj = parentObj[ arrFunctionName.shift() ];
+                }
+                var fnc : Function = functionObj as Function;
                 if (fnc)
                 {
-                    return fnc.apply(null, args);
+                    return fnc.apply(parentObj, args);
                 }
                 return null;
             }


### PR DESCRIPTION
If a function name of 'window.object.fnc' is passed in, we now correctly parse this string to get a reference to the 'fnc' and call it with the 'window.object' as the 'this' parameter