### PR TITLE
fix getElementIndex, use positioner instead of element

### DIFF
--- a/frameworks/projects/Basic/src/main/royale/org/apache/royale/core/UIBase.as
+++ b/frameworks/projects/Basic/src/main/royale/org/apache/royale/core/UIBase.as
@@ -1350,7 +1350,7 @@ package org.apache.royale.core
                 var n:int = children.length;
                 for (var i:int = 0; i < n; i++)
                 {
-                    if (children[i] === c.element)
+                    if (children[i] === c.positioner)
                         return i;
                 }
                 return -1;                


### PR DESCRIPTION
Checked UIBase.as, I think only getElementIndex() need to use positioner instead of element