### PR TITLE
fix Channelset login/logout throwing an Error

### DIFF
--- a/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/ChannelSet.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/ChannelSet.as
@@ -1343,14 +1343,14 @@ public class ChannelSet extends EventDispatcher
             var i:int = 0;
             for (; i < n; i++)
             {
-                _messageAgents[i].internalSetCredentials(null);
+                MessageAgent(_messageAgents[i]).internalSetCredentials(null);
             }
             n = _channels.length;
             for (i = 0; i < n; i++)
             {
                 if (_channels[i] != null)
                 {
-                    _channels[i].internalSetCredentials(null);
+                    Channel(_channels[i]).internalSetCredentials(null);
                     if (_channels[i] is PollingChannel)
                         PollingChannel(_channels[i]).disablePolling();
                 }
@@ -1528,13 +1528,13 @@ public class ChannelSet extends EventDispatcher
             var i:int = 0;
             for (; i < n; i++)
             {
-                _messageAgents[i].internalSetCredentials(creds);
+                MessageAgent(_messageAgents[i]).internalSetCredentials(creds);
             }
             n = _channels.length;
             for (i = 0; i < n; i++)
             {
                 if (_channels[i] != null)
-                    _channels[i].internalSetCredentials(creds);
+                    Channel(_channels[i]).internalSetCredentials(creds);
             }
 
             agent.state = AuthenticationAgent.LOGGED_IN_STATE;


### PR DESCRIPTION
Found a bug with RemoteObject login and logout (partly) failing. The issue is revealed when doing a logout and re-login on an already authenticated channel.

Root cause:
internalSetCredentials is in mx_internal namespace and the name does not correctly get converted in javascript transpiled code.

Fix:
added explicit cast of array element to base class for compiler to pick up correct function naming.