### PR TITLE
Update issue#486 (part1) prevent currentStateChange event to be fired if set same state as current

### DIFF
--- a/frameworks/projects/Basic/src/main/royale/org/apache/royale/core/GroupBase.as
+++ b/frameworks/projects/Basic/src/main/royale/org/apache/royale/core/GroupBase.as
@@ -254,6 +254,7 @@ package org.apache.royale.core
          */
         public function set currentState(value:String):void
         {
+			if (value == _currentState) return;
             var event:ValueChangeEvent = new ValueChangeEvent("currentStateChange", false, false, _currentState, value)
             _currentState = value;
             dispatchEvent(event);


### PR DESCRIPTION
Don't dispatch "currentStateChange" event  if setted state is the same as _currentState (see issue #486)