### PR TITLE
Update issue#486 (part2) prevent currentStateChange event to be fired if set same state as current

### DIFF
--- a/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/MXMLBeadView.as
+++ b/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/MXMLBeadView.as
@@ -217,6 +217,7 @@ package org.apache.royale.html
          */
         public function set currentState(value:String):void
         {
+			if (value == _currentState) return;
             var event:ValueChangeEvent = new ValueChangeEvent("currentStateChange", false, false, _currentState, value)
             _currentState = value;
             dispatchEvent(event);

--- a/frameworks/projects/CreateJS/src/main/royale/org/apache/royale/createjs/Container.as
+++ b/frameworks/projects/CreateJS/src/main/royale/org/apache/royale/createjs/Container.as
@@ -272,6 +272,7 @@ package org.apache.royale.createjs
 		 */
 		public function set currentState(value:String):void
 		{
+			if (value == _currentState) return;
 			var event:ValueChangeEvent = new ValueChangeEvent("currentStateChange", false, false, _currentState, value)
 			_currentState = value;
 			dispatchEvent(event);

--- a/frameworks/projects/CreateJS/src/main/royale/org/apache/royale/createjs/core/View.as
+++ b/frameworks/projects/CreateJS/src/main/royale/org/apache/royale/createjs/core/View.as
@@ -301,6 +301,7 @@ package org.apache.royale.createjs.core
 		 */
 		public function set currentState(value:String):void
 		{
+			if (value == _currentState) return;
 			var event:ValueChangeEvent = new ValueChangeEvent("currentStateChange", false, false, _currentState, value)
 			_currentState = value;
 			dispatchEvent(event);

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/core/UIComponent.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/core/UIComponent.as
@@ -3051,6 +3051,7 @@ COMPILE::JS
      */
     public function set currentState(value:String):void
     {
+    	if (value == _currentState) return;
         var event:ValueChangeEvent = new ValueChangeEvent("currentStateChange", false, false, _currentState, value)
         _currentState = value;
         addEventListener("stateChangeComplete", stateChangeCompleteHandler);


### PR DESCRIPTION
Don't dispatch "currentStateChange" event  if set state is the same as _currentState (see issue #486)