### PR TITLE
Order of header and footer reversed

### DIFF
--- a/frameworks/projects/Effects/src/main/royale/org/apache/royale/core/StatesWithTransitionsImpl.as
+++ b/frameworks/projects/Effects/src/main/royale/org/apache/royale/core/StatesWithTransitionsImpl.as
@@ -330,6 +330,10 @@ package org.apache.royale.core
 	                                childrenAdded = true;
 								}
                             }
+							else if (ai.position == "first")
+							{
+								parent.addElementAt(item, 0);
+							}
                             else
                             {
                                 parent.addElement(item);


### PR DESCRIPTION
Due to synchronization problem between the files StatesWithTransitionsImpl and SimpleStatesImpl, header is placed under footer. Fixed making relevant changes