### PR TITLE
jewel: fix backward grid layouts for desktop & widescreen

### DIFF
--- a/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/layouts/GridCellLayout.as
+++ b/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/layouts/GridCellLayout.as
@@ -76,8 +76,8 @@ package org.apache.royale.jewel.beads.layouts
 
 			COMPILE::JS
 			{
-				setFractionForScreen(DESKTOP, _wideScreenNumerator, _wideScreenDenominator);
-				setFractionForScreen(WIDESCREEN, _desktopNumerator, _desktopDenominator);
+				setFractionForScreen(WIDESCREEN, _wideScreenNumerator, _wideScreenDenominator);
+				setFractionForScreen(DESKTOP, _desktopNumerator, _desktopDenominator);
 				setFractionForScreen(TABLET, _tabletNumerator, _tabletDenominator);
 				setFractionForScreen(PHONE, _phoneNumerator, _phoneDenominator);
 			}


### PR DESCRIPTION
I've noticed that the Grid Cell Layouts were reversed for Desktop and Widescreen in TourDeJewel and my local testing. Found this backwards assignment while hunting around.