### PR TITLE
ArrayList: make length binding update when an item is added or removed

### DIFF
--- a/frameworks/projects/Collections/src/main/royale/org/apache/royale/collections/ArrayList.as
+++ b/frameworks/projects/Collections/src/main/royale/org/apache/royale/collections/ArrayList.as
@@ -278,6 +278,8 @@ package org.apache.royale.collections
 			collectionEvent.item = item;
 			collectionEvent.index = index;
 			dispatchEvent(collectionEvent);
+
+			dispatchEvent(new Event("lengthChanged"));
 		}
 
 		/**
@@ -363,6 +365,8 @@ package org.apache.royale.collections
             collectionEvent.item = removed;
 			collectionEvent.index = index;
             dispatchEvent(collectionEvent);
+
+			dispatchEvent(new Event("lengthChanged"));
 
 			return removed;
 		}


### PR DESCRIPTION
I noticed that the `[Bindable("lengthChanged")]` was added to the length property, but the event is not dispatched when an item is either added or removed.

**Steps to Reproduce**

1. _Create a bindable ArrayList_

```
[Bindable]
public var names:ArrayList = new ArrayList(["A", "B", "C"]);
```

2. _Bind something to the length property_

```
<j:Label text="Length: {names.length}"/>
```

3. _Add an item_

```
names.addItem("D");
```

**Expected Results**

Label is updated from `Length: 3` to `Length: 4`.

**Actual Results**

Label is not updated and remains as `Length: 3`.