### PR TITLE
ErrorImage Bead for IImage implement

### DIFF
--- a/examples/jewel/TourDeJewel/src/main/royale/ImagePlayGround.mxml
+++ b/examples/jewel/TourDeJewel/src/main/royale/ImagePlayGround.mxml
@@ -66,6 +66,29 @@ limitations under the License.
 				<j:Label localId="imageButtonResult" text="Image is an input type='image' tag in html"/>
 			</j:Card>
 		</j:GridCell>
+
+		<j:GridCell desktopNumerator="1" desktopDenominator="2" tabletNumerator="1" tabletDenominator="2" phoneNumerator="1" phoneDenominator="1">
+			<j:Card>
+				<html:H3 text="Jewel Image with bead error image alternative"/>
+
+				<j:Image localId="imageWithErrorBead" src="assets/royale.png">
+					<j:beads>
+                        <js:ErrorImage src="assets/royale_spheres.png" emptyIsError="true"/>
+					</j:beads>
+				</j:Image>
+			</j:Card>
+		</j:GridCell>
+		<j:GridCell desktopNumerator="1" desktopDenominator="2" tabletNumerator="1" tabletDenominator="2" phoneNumerator="1" phoneDenominator="1">
+			<j:Card>
+				<html:H4 text="Basic Image with bead error image alternative"/>
+
+				<js:Image localId="imageBasicErrorBead" src="assets/royale.png">
+					<js:beads>
+                        <js:ErrorImage src="assets/royale_spheres.png" emptyIsError="true"/>
+					</js:beads>
+				</js:Image>
+			</j:Card>
+		</j:GridCell>
 	</j:Grid>
 
 </c:ExampleAndSourceCodeTabbedSectionContent>

--- a/frameworks/projects/Basic/src/main/resources/basic-manifest.xml
+++ b/frameworks/projects/Basic/src/main/resources/basic-manifest.xml
@@ -296,5 +296,8 @@
     <component id="UIGraphicsBase" class="org.apache.royale.display.UIGraphicsBase"/>
 	
 	<component id="CollectionSelectedItemByField" class="org.apache.royale.html.beads.CollectionSelectedItemByField"/>
-
+    <component id="ErrorImage" class="org.apache.royale.html.beads.ErrorImage"/>
+	
+	
+	
 </componentPackage>

--- a/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/beads/ErrorImage.as
+++ b/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/beads/ErrorImage.as
@@ -1,0 +1,151 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+package org.apache.royale.html.beads {
+
+    import org.apache.royale.core.IBead;
+    import org.apache.royale.core.IStrand;
+    import org.apache.royale.events.Event;
+
+    import org.apache.royale.events.EventDispatcher;
+	import org.apache.royale.core.IImage;
+    import org.apache.royale.core.IImageModel;
+  
+  /**
+	 *  The ErrorImage class is a bead that can be used to 
+     *  display an alternate image, in the event that the specified image 
+     *  cannot be loaded.
+     * 
+     *  It will be supported by controls that load the ImageModel bead and 
+     *  implement the IImage interface
+	 *  
+	 *  @langversion 3.0
+	 *  @playerversion Flash 10.2
+	 *  @playerversion AIR 2.6
+	 *  @productversion Royale 0.9.8
+	 */
+
+    public class ErrorImage implements IBead {
+
+        protected var _strand:IStrand;
+
+        public function ErrorImage() {            
+        }
+
+        private var _src:String;
+		/**
+		 *  The source of the image
+		 */
+        public function get src():String {
+            return _src;
+        }
+
+        public function set src(value:String):void {
+            _src = value;
+        }
+        
+		COMPILE::JS{
+        private var _hostElement:HTMLImageElement;
+		protected function get hostElement():HTMLImageElement
+		{
+			return _hostElement;
+		}
+        }
+        protected function get hostModel():IImageModel
+        {             
+            return _strand.getBeadByType(IImageModel) as IImageModel;
+        }
+
+        /**
+         *  @copy org.apache.royale.core.IBead#strand
+         *
+         *  @langversion 3.0
+         *  @playerversion Flash 10.2
+         *  @playerversion AIR 2.6
+         *  @productversion Royale 0.9.8
+         */
+        public function set strand(value:IStrand):void 
+        {
+            _strand = value;
+
+	        COMPILE::JS {
+
+                if(_strand is IImage)
+                {
+                    _hostElement = (_strand as IImage).imageElement as HTMLImageElement;
+                    if(_hostElement){
+                        
+                        _hostElement.addEventListener('error', errorHandler);
+
+                        if(_emptyIsError)
+                        {
+                            (_strand as EventDispatcher).addEventListener("beadsAdded", beadsAddedHandler);
+                        }
+                    }   
+                }
+            }
+        }
+
+		COMPILE::JS
+        private function beadsAddedHandler(event:Event):void
+        {
+            (_strand as EventDispatcher).removeEventListener("beadsAdded", beadsAddedHandler);
+
+            if(hostModel)
+                hostModel.addEventListener("urlChanged",srcChangedHandler);
+            srcChangedHandler(null);
+        }
+
+        private var _emptyIsError:Boolean = false;
+        public function get emptyIsError():Boolean {
+            return _emptyIsError;
+        }
+        public function set emptyIsError(value:Boolean):void {
+            _emptyIsError = value;
+        }
+
+		COMPILE::JS
+        private function errorHandler(event:Event):void {
+        
+            if (hostElement.src != _src)
+            {
+                hostElement.src = _src;
+            }
+        }
+		
+        private function srcChangedHandler(event:Event):void
+        {
+            if(hostModel && !hostModel.url){
+                
+                COMPILE::JS {
+                    // Op1: Updating the model (It causes a double assignment that we must control)
+                    if(hostModel.hasEventListener("urlChanged")){
+                        hostModel.removeEventListener("urlChanged",srcChangedHandler);
+                        hostModel.url = src;
+                        hostModel.addEventListener("urlChanged",srcChangedHandler);                    
+                    }
+                    // Op2: Direct assignment to element
+                    //(hostElement as Object).src = src;
+                }                    
+            }
+            
+        }
+
+    }
+}
+

--- a/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/beads/ErrorImage.as
+++ b/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/beads/ErrorImage.as
@@ -112,6 +112,9 @@ package org.apache.royale.html.beads {
         }
 
         private var _emptyIsError:Boolean = false;
+		/**
+		 *  Indicates whether the "empty or null" values will be treated as errors and replaced by the indicated src
+		 */
         public function get emptyIsError():Boolean {
             return _emptyIsError;
         }
@@ -130,18 +133,15 @@ package org.apache.royale.html.beads {
 		
         private function srcChangedHandler(event:Event):void
         {
-            if(hostModel && !hostModel.url){
-                
-                COMPILE::JS {
-                    // Op1: Updating the model (It causes a double assignment that we must control)
-                    if(hostModel.hasEventListener("urlChanged")){
-                        hostModel.removeEventListener("urlChanged",srcChangedHandler);
-                        hostModel.url = src;
-                        hostModel.addEventListener("urlChanged",srcChangedHandler);                    
-                    }
-                    // Op2: Direct assignment to element
-                    //(hostElement as Object).src = src;
-                }                    
+            if(hostModel && !hostModel.url){                
+                // Op1: Updating the model (It causes a double assignment that we must control)
+                if(hostModel.hasEventListener("urlChanged")){
+                    hostModel.removeEventListener("urlChanged",srcChangedHandler);
+                    hostModel.url = src;
+                    hostModel.addEventListener("urlChanged",srcChangedHandler);                    
+                }
+                // Op2: Direct assignment to element
+                //(hostElement as Object).src = src;
             }
             
         }

--- a/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/beads/ErrorImage.as
+++ b/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/beads/ErrorImage.as
@@ -44,13 +44,27 @@ package org.apache.royale.html.beads {
 
         protected var _strand:IStrand;
 
+        /**
+         *  constructor.
+         *
+         * 
+         *  @langversion 3.0
+         *  @playerversion Flash 10.2
+         *  @playerversion AIR 2.6
+         *  @productversion Royale 0.9.8
+        */
         public function ErrorImage() {            
         }
 
         private var _src:String;
 		/**
 		 *  The source of the image
-		 */
+         * 
+         *  @langversion 3.0
+         *  @playerversion Flash 10.2
+         *  @playerversion AIR 2.6
+         *  @productversion Royale 0.9.8
+        */
         public function get src():String {
             return _src;
         }
@@ -114,7 +128,12 @@ package org.apache.royale.html.beads {
         private var _emptyIsError:Boolean = false;
 		/**
 		 *  Indicates whether the "empty or null" values will be treated as errors and replaced by the indicated src
-		 */
+         * 
+         *  @langversion 3.0
+         *  @playerversion Flash 10.2
+         *  @playerversion AIR 2.6
+         *  @productversion Royale 0.9.8
+        */
         public function get emptyIsError():Boolean {
             return _emptyIsError;
         }


### PR DESCRIPTION
The ErrorImage class is a bead that can be used to display an alternate image, in the event that the specified image cannot be loaded.
It will be supported by controls that load the ImageModel bead and implement the IImage interface.
