### PR TITLE
ArrayListView: Dispatch lengthChanged binding event if necessary after a refresh

### DIFF
--- a/frameworks/projects/Collections/src/main/royale/org/apache/royale/collections/ArrayListView.as
+++ b/frameworks/projects/Collections/src/main/royale/org/apache/royale/collections/ArrayListView.as
@@ -522,8 +522,13 @@ public class ArrayListView extends EventDispatcher implements IArrayListView, IA
      *  @productversion Royale 0.0
      */
     public function refresh():Boolean {
+        var lengthChanged:Boolean = internalRefresh(true);
 
-        return internalRefresh(true);
+        if (lengthChanged) {
+            dispatchEvent(new Event('lengthChanged'));
+        }
+
+        return lengthChanged;
     }
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
ArrayListView does not dispatch a "lengthChanged" event after performing a refresh which can alter the length from a filter.

**Steps to Reproduce**

1. _Create a bindable ArrayListView_

```
[Bindable]
public var names:ArrayListView = new ArrayListView(new ArrayList(["A", "B", "C"]));
```

2. _Bind something to the length property_

```
<j:Label text="Length: {names.length}"/>
```

3. _Add a filter and refresh_

```
names.filterFunction = filterFunctionThatRemovesB;
names.refresh();
```

**Expected Results**

Label is updated from `Length: 3` to `Length: 2`.

**Actual Results**

Label is not updated and remains as `Length: 3`.