### PR TITLE
Crux: Fix a typo where COMPILE::JS should have been used over SWF

### DIFF
--- a/frameworks/projects/Crux/src/main/royale/org/apache/royale/crux/processors/ViewProcessor.as
+++ b/frameworks/projects/Crux/src/main/royale/org/apache/royale/crux/processors/ViewProcessor.as
@@ -128,7 +128,7 @@ package org.apache.royale.crux.processors
 				COMPILE::SWF{
 					arr = views[ viewType ] as Array;
 				}
-				COMPILE::SWF{
+				COMPILE::JS{
 					arr = views.get(viewType) as Array;
 				}
 				


### PR DESCRIPTION
Found a small bug where COMPILE::SWF was used to used to retrieve a value from a map that should have been for JS.