### PR TITLE
jewel-listitemrenderer: Partial revert of data setter so dataChange event can fire when necessary

### DIFF
--- a/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/itemRenderers/ListItemRenderer.as
+++ b/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/itemRenderers/ListItemRenderer.as
@@ -136,14 +136,15 @@ package org.apache.royale.jewel.itemRenderers
 		 *  @playerversion AIR 2.6
 		 *  @productversion Royale 0.9.4
 		 */
-        override public function set data(value:Object):void
-        {
+		override public function set data(value:Object):void
+		{
 			if(labelFunctionBead && labelFunctionBead.labelFunction)
 				text = labelFunctionBead.labelFunction(value);
 			else
-            	text = getLabelFromData(this, value);
-            _data = value;
-        }
+				text = getLabelFromData(this, value);
+
+			super.data = value;
+		}
 
         /**
          * @royaleignorecoercion org.apache.royale.core.WrappedHTMLElement


### PR DESCRIPTION
This small fix reverts part of a recent change that allows the "dataChange" event to fire when data is changed.