### PR TITLE
Fixed Jewel ComboBox freeze with SearchFilter

### DIFF
--- a/frameworks/projects/Core/src/main/royale/org/apache/royale/core/Bead.as
+++ b/frameworks/projects/Core/src/main/royale/org/apache/royale/core/Bead.as
@@ -71,5 +71,13 @@ package org.apache.royale.core
       (_strand as IEventDispatcher).addEventListener(eventType, handler, capture);
     }
 
+    /**
+     * Helper function to remove event listener without the need for casting
+     * @royaleignorecoercion org.apache.royale.events.IEventDispatcher
+     */
+    protected function unlistenOnStrand(eventType:String,handler:Function,capture:Boolean=false):void
+    {
+      (_strand as IEventDispatcher).removeEventListener(eventType, handler, capture);
+    }
   }
 }

--- a/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/controls/combobox/SearchFilter.as
+++ b/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/controls/combobox/SearchFilter.as
@@ -23,6 +23,8 @@ package org.apache.royale.jewel.beads.controls.combobox
 	import org.apache.royale.jewel.beads.controls.textinput.SearchFilterForList;
 	import org.apache.royale.jewel.beads.views.ComboBoxView;
 	import org.apache.royale.jewel.supportClasses.textinput.TextInputBase;
+    import org.apache.royale.jewel.List;
+    import org.apache.royale.events.MouseEvent;
 
 	/**
 	 *  The SearchFilter bead class is a specialty bead that can be used with
@@ -46,6 +48,22 @@ package org.apache.royale.jewel.beads.controls.combobox
 		public function SearchFilter()
 		{
 		}
+
+        public override function set list(value:List):void
+        {
+            super.list = value;
+            COMPILE::JS
+			{
+			if (list != null)
+	            list.addEventListener(MouseEvent.CLICK, onListClick);
+            }
+        }
+
+        private function onListClick(event:MouseEvent):void
+        {
+			list.removeEventListener(MouseEvent.CLICK, onListClick);
+            comboView.popUpVisible = false;
+        }
 
 		private var comboView:IComboBoxView;
 


### PR DESCRIPTION
Fixed the following issue:
1. Locate ComboBox on Tour de Jewel components;
2. Go to Local Search Filter sample;
3. Select any item with mouse;
4. Select all text and type "i";
5. The only option will be "Iron Man" and at this point you coun’t select the option or close the list and the application would freeze.