### PR TITLE
XMLList: added localName()

### DIFF
--- a/frameworks/projects/XML/src/main/royale/XMLList.as
+++ b/frameworks/projects/XML/src/main/royale/XMLList.as
@@ -1454,6 +1454,15 @@ package
 			throwError("Incompatible assignment of XMLList to XML");
 			return null;
 		}
+
+		public function localName():String
+		{
+			if (isSingle())
+				return _xmlArray[0].localName();
+			
+			throwError("Incompatible assignment of XMLList to XML");
+			return null;
+		}
 	}
 }
 


### PR DESCRIPTION
Existing Flex code can call localName() on an XMLList object.

Not sure if there is some automatic conversion that needs to be implemented, or if you prefer that people call toXML().localName(), but adding localName() to XMLList seems like the easiest way to get existing code to compile unchanged.
