### PR TITLE
Commented out function causing a VerifyError: Error #1053 in Flash Debug Player

### DIFF
--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/supportClasses/GroupBase.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/supportClasses/GroupBase.as
@@ -1442,9 +1442,8 @@ public class GroupBase extends UIComponent implements ILayoutParent, IContainer,
     /**
      *  @private 
      */ 
-    override public function globalToLocal(point:Point):Point
+    /* override public function globalToLocal(point:Point):Point
     {
-		/*
         if (resizeMode == ResizeMode.SCALE && _layoutFeatures != null)
         {
             // If resize mode is scale, then globalToLocal shouldn't account for 
@@ -1468,9 +1467,8 @@ public class GroupBase extends UIComponent implements ILayoutParent, IContainer,
         {
             return super.globalToLocal(point);    
         }
-		*/
 		return null;
-    }
+    } */
     
     /**
      *  @private 


### PR DESCRIPTION
Function doesn't seem to be implemented, anyway.  (Check-in comment was blank.)

This is an instance of the problem described in issue #953.  Though, I'm not sure why it is happening in this case;  SWFOverride for the function (in a parent class) doesn't cause problems for other functions, and this function signature otherwise looks correct.