### PR TITLE
Fix VerifyError: Error #1053 in Flash Debug Player due to mismatched types

### DIFF
--- a/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/messages/AbstractMessage.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/messages/AbstractMessage.as
@@ -21,8 +21,16 @@ package mx.messaging.messages
 {
 
 import org.apache.royale.utils.BinaryData;
-import org.apache.royale.utils.net.IDataInput;
-import org.apache.royale.utils.net.IDataOutput;
+
+COMPILE::JS {
+	import org.apache.royale.utils.net.IDataInput;
+	import org.apache.royale.utils.net.IDataOutput;
+}
+COMPILE::SWF{
+	import flash.utils.IDataInput;
+	import flash.utils.IDataOutput;
+}
+
 import org.apache.royale.reflection.getQualifiedClassName;
 
 import mx.core.mx_internal;

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/messages/AcknowledgeMessage.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/messages/AcknowledgeMessage.as
@@ -20,8 +20,14 @@
 package mx.messaging.messages
 {
 
-import org.apache.royale.utils.net.IDataInput;
-import org.apache.royale.utils.net.IDataOutput;
+COMPILE::JS {
+	import org.apache.royale.utils.net.IDataInput;
+	import org.apache.royale.utils.net.IDataOutput;
+}
+COMPILE::SWF{
+	import flash.utils.IDataInput;
+	import flash.utils.IDataOutput;
+}
 
 [RemoteClass(alias="flex.messaging.messages.AcknowledgeMessage")]
 

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/messages/AcknowledgeMessageExt.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/messages/AcknowledgeMessageExt.as
@@ -20,7 +20,12 @@
 package mx.messaging.messages
 {
 
-import org.apache.royale.utils.net.IDataOutput;
+COMPILE::JS {
+	import org.apache.royale.utils.net.IDataOutput;
+}
+COMPILE::SWF{
+	import flash.utils.IDataOutput;
+}
 import org.apache.royale.utils.net.IExternalizable;
 
 [RemoteClass(alias="DSK")]

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/messages/AsyncMessage.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/messages/AsyncMessage.as
@@ -21,8 +21,15 @@ package mx.messaging.messages
 {
 
 import org.apache.royale.utils.BinaryData;
-import org.apache.royale.utils.net.IDataInput;
-import org.apache.royale.utils.net.IDataOutput;
+
+COMPILE::JS {
+	import org.apache.royale.utils.net.IDataInput;
+	import org.apache.royale.utils.net.IDataOutput;
+}
+COMPILE::SWF{
+	import flash.utils.IDataInput;
+	import flash.utils.IDataOutput;
+}
 
 import mx.utils.RPCUIDUtil;
 

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/messages/AsyncMessageExt.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/messages/AsyncMessageExt.as
@@ -20,7 +20,12 @@
 package mx.messaging.messages
 {
 
-import org.apache.royale.utils.net.IDataOutput;
+COMPILE::JS {
+	import org.apache.royale.utils.net.IDataOutput;
+}
+COMPILE::SWF{
+	import flash.utils.IDataOutput;
+}
 import org.apache.royale.utils.net.IExternalizable;
 
 [RemoteClass(alias="DSA")]

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/messages/CommandMessage.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/messages/CommandMessage.as
@@ -20,8 +20,14 @@
 package mx.messaging.messages
 {
 
-import org.apache.royale.utils.net.IDataInput;
-import org.apache.royale.utils.net.IDataOutput;
+COMPILE::JS {
+	import org.apache.royale.utils.net.IDataInput;
+	import org.apache.royale.utils.net.IDataOutput;
+}
+COMPILE::SWF{
+	import flash.utils.IDataInput;
+	import flash.utils.IDataOutput;
+}
 import org.apache.royale.utils.net.IExternalizable;
 
 [RemoteClass(alias="flex.messaging.messages.CommandMessage")]

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/messages/CommandMessageExt.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/messages/CommandMessageExt.as
@@ -20,7 +20,12 @@
 package mx.messaging.messages
 {
 
-import org.apache.royale.utils.net.IDataOutput;
+COMPILE::JS {
+	import org.apache.royale.utils.net.IDataOutput;
+}
+COMPILE::SWF{
+	import flash.utils.IDataOutput;
+}
 import org.apache.royale.utils.net.IExternalizable;
 
 [RemoteClass(alias="DSC")]

--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/DataGroup.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/DataGroup.as
@@ -504,6 +504,7 @@ public class DataGroup extends GroupBase implements IItemRendererProvider, IStra
      *  @playerversion AIR 1.5
      *  @productversion Flex 4
      */
+    [SWFOverride(returns="org.apache.royale.core.IFactory")]
     public function get itemRenderer():IFactory
     {
         return _itemRenderer;
@@ -512,6 +513,7 @@ public class DataGroup extends GroupBase implements IItemRendererProvider, IStra
     /**
      *  @private
      */
+    [SWFOverride(params="org.apache.royale.core.IFactory", altparams="mx.core.IFactory")]
     public function set itemRenderer(value:IFactory):void
     {
         _itemRenderer = value;


### PR DESCRIPTION
Fix VerifyError: Error #1053 in Flash Debug Player due to wrong IDataInput / IDataOutput used in mx.messaging.messages.* classes, and due to mismatch of IFactory type between spark.components.DataGroup and IItemRendererProvider.  (Both are the problem described in issue #953.)

For mx.messaging.messages.*, the conditional imports for IDataInput / IDataOutput (for IExternalizable) used elsewhere were not used here.  The compiler didn't complain.

For DataGroup, there is a problem that it defines set/get itemRenderer with mx.core.IFactory, but it's implementing IItemRendererProvider that uses org.apache.royale.core.IFactory.  This is hard to reconcile, so I used SWFOverride.  (FYI, mx.controls.listClasses.ListBase uses org.apache.royale.core.IFactory when implementing IItemRendererProvider, so there's some inconsistency.)
