### PR TITLE
Implemented JS side of XMLNotifier, ObjectMap.forEach, and many XML notifications.

### DIFF
--- a/frameworks/projects/Core/src/main/royale/org/apache/royale/utils/ObjectMap.as
+++ b/frameworks/projects/Core/src/main/royale/org/apache/royale/utils/ObjectMap.as
@@ -42,9 +42,10 @@ package org.apache.royale.utils
 
     public class ObjectMap
     {
-        public function ObjectMap(weak:Boolean=false)
+        public function ObjectMap(weak:Boolean=false,forceEnumerable:Boolean=false)
         {
             _weak = weak;
+            _forceEnumerable = forceEnumerable;
             COMPILE::SWF
             {
                 _map = new Dictionary(weak);
@@ -58,7 +59,7 @@ package org.apache.royale.utils
         COMPILE::JS
         private function makeMap():void
         {
-            if(_weak && typeof WeakMap == "function")
+            if(_weak && !_forceEnumerable && typeof WeakMap == "function")
             {
                 _map = new WeakMap();
                 assignFunctions();
@@ -78,6 +79,7 @@ package org.apache.royale.utils
         }
 
         private var _weak:Boolean;
+        private var _forceEnumerable:Boolean;
         private var _map:Object;
         private var _usesObjects:Boolean = false;
 
@@ -93,6 +95,23 @@ package org.apache.royale.utils
         public function delete(key:Object):void
         {
             delete _map[key];
+        }
+
+        /**
+         *  Perform function for each pair.
+         *  @langversion 3.0
+         *  @playerversion Flash 10.2
+         *  @playerversion AIR 2.6
+         *  @productversion Royale 0.9.8
+         * 
+         */
+        COMPILE::SWF
+        public function forEach(callback:Function,thisArg:Object=null):void
+        {
+            for (var key:Object in _map)
+            {
+                callback(_map[key],key,_map);
+            }
         }
 
         /**
@@ -173,6 +192,10 @@ package org.apache.royale.utils
              *  @royalesuppresspublicvarwarning
              */
             public var delete:Function = objectDelete;
+            /**
+             *  @royalesuppresspublicvarwarning
+             */
+            public var forEach:Function = objectForEach;
         }
 
         COMPILE::JS
@@ -182,6 +205,7 @@ package org.apache.royale.utils
             this.has = _map.has.bind(_map);
             this.set = _map.set.bind(_map);
             this.delete = _map.delete.bind(_map);
+            this.forEach = (_weak ? null : _map.forEach.bind(_map));
         }
 
         COMPILE::JS
@@ -228,6 +252,12 @@ package org.apache.royale.utils
             }
         }
         COMPILE::JS
+        private function objectForEach(callback:Function,thisArg:Object=null):void
+        {
+		// if (_weak) throw ...
+		trace("ObjectMap::objectForEach() not implemented in this browser");
+        }
+        COMPILE::JS
         public function clear():void
         {
             if(_usesObjects)
@@ -243,6 +273,5 @@ package org.apache.royale.utils
                 assignFunctions();
             }
         }
-
     }    
 }

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/utils/XMLNotifier.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/utils/XMLNotifier.as
@@ -94,7 +94,7 @@ public class XMLNotifier
                                                      value:Object,
                                                      detail:Object):void
         {
-            var xmlWatchers:ObjectMap = (callee as Object).watched;
+            var xmlWatchers:ObjectMap = callee["watched"];
             if (xmlWatchers != null)
             {
                 xmlWatchers.forEach( function(truevalue:Object,notifiable:Object,map:Object):void {
@@ -116,7 +116,7 @@ public class XMLNotifier
                                                      detail:Object):void
         {
             var callee:Function = notificationFunction;
-            var xmlWatchers:ObjectMap = (callee as Object).watched;
+            var xmlWatchers:ObjectMap = callee["watched"];
             if (xmlWatchers != null)
             {
                 xmlWatchers.forEach( function(truevalue:Object,notifiable:Object,map:Object):void {

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/utils/XMLNotifier.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/utils/XMLNotifier.as
@@ -20,10 +20,7 @@
 package mx.utils
 {
 
-COMPILE::SWF
-{
-import flash.utils.Dictionary;
-}
+import org.apache.royale.utils.ObjectMap;
 import mx.core.mx_internal;
 import mx.utils.IXMLNotifiable;
 
@@ -88,6 +85,28 @@ public class XMLNotifier
      *  Decorates an XML node with a notification function
      *  that can fan out to multiple targets.
      */
+    COMPILE::JS
+    mx_internal static function initializeXMLForNotification():Function
+    {
+        var notificationFunction:Function = function(callee:Function, currentTarget:Object,
+                                                     ty:String,
+                                                     tar:Object,
+                                                     value:Object,
+                                                     detail:Object):void
+        {
+            var xmlWatchers:ObjectMap = (callee as Object).watched;
+            if (xmlWatchers != null)
+            {
+                xmlWatchers.forEach( function(truevalue:Object,notifiable:Object,map:Object):void {
+                    IXMLNotifiable(notifiable).xmlNotification(currentTarget, ty, tar, value, detail);
+                } );
+            }
+        }
+
+        return notificationFunction;
+    }
+
+    COMPILE::SWF
     mx_internal static function initializeXMLForNotification():Function
     {
         var notificationFunction:Function = function(currentTarget:Object,
@@ -96,16 +115,13 @@ public class XMLNotifier
                                                      value:Object,
                                                      detail:Object):void
         {
-            COMPILE::SWF
-            {
-            var xmlWatchers:Dictionary = arguments.callee.watched;
+            var callee:Function = notificationFunction;
+            var xmlWatchers:ObjectMap = (callee as Object).watched;
             if (xmlWatchers != null)
             {
-                for (var notifiable:Object in xmlWatchers)
-                {
+                xmlWatchers.forEach( function(truevalue:Object,notifiable:Object,map:Object):void {
                     IXMLNotifiable(notifiable).xmlNotification(currentTarget, ty, tar, value, detail);
-                }
-            }
+                } );
             }
         }
 
@@ -171,8 +187,6 @@ public class XMLNotifier
             // access the notification() function.
             var xmlItem:XML = XML(xml);
 
-            COMPILE::SWF
-            {
             // First make sure the xml node has a notification function.
             var watcherFunction:Object = xmlItem.notification();
 
@@ -185,14 +199,13 @@ public class XMLNotifier
             }
 
             // Watch lists are maintained on the notification function.
-            var xmlWatchers:Dictionary;
+            var xmlWatchers:ObjectMap;
             if (watcherFunction["watched"] == undefined)
-                watcherFunction["watched"] = xmlWatchers = new Dictionary(true);
+                watcherFunction["watched"] = xmlWatchers = new ObjectMap(true,true);
             else
                 xmlWatchers = watcherFunction["watched"];
-            
-            xmlWatchers[notifiable] = true;
-            }
+
+            xmlWatchers.set(notifiable, true);
         }
     }
 
@@ -223,21 +236,18 @@ public class XMLNotifier
             // access the notification() function.
             var xmlItem:XML = XML(xml);
 
-            COMPILE::SWF
-            {
             var watcherFunction:Object = xmlItem.notification();
 
             if (!(watcherFunction is Function))
                 return;
 
-            var xmlWatchers:Dictionary;
+            var xmlWatchers:ObjectMap;
 
             if (watcherFunction["watched"] != undefined)
             {
                 xmlWatchers = watcherFunction["watched"];
-                delete xmlWatchers[notifiable];
+                xmlWatchers.delete(notifiable);
             }           
-            }
         }
     }
 }

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/utils/XMLNotifier.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/utils/XMLNotifier.as
@@ -85,37 +85,19 @@ public class XMLNotifier
      *  Decorates an XML node with a notification function
      *  that can fan out to multiple targets.
      */
-    COMPILE::JS
-    mx_internal static function initializeXMLForNotification():Function
-    {
-        var notificationFunction:Function = function(callee:Function, currentTarget:Object,
-                                                     ty:String,
-                                                     tar:Object,
-                                                     value:Object,
-                                                     detail:Object):void
-        {
-            var xmlWatchers:ObjectMap = callee["watched"];
-            if (xmlWatchers != null)
-            {
-                xmlWatchers.forEach( function(truevalue:Object,notifiable:Object,map:Object):void {
-                    IXMLNotifiable(notifiable).xmlNotification(currentTarget, ty, tar, value, detail);
-                } );
-            }
-        }
-
-        return notificationFunction;
-    }
-
-    COMPILE::SWF
     mx_internal static function initializeXMLForNotification():Function
     {
         var notificationFunction:Function = function(currentTarget:Object,
                                                      ty:String,
                                                      tar:Object,
                                                      value:Object,
-                                                     detail:Object):void
+                                                     detail:Object,
+                                                     callee:Function = null):void
         {
-            var callee:Function = notificationFunction;
+            COMPILE::SWF
+            {
+                callee = notificationFunction;
+            }
             var xmlWatchers:ObjectMap = callee["watched"];
             if (xmlWatchers != null)
             {

--- a/frameworks/projects/XML/src/main/royale/XML.as
+++ b/frameworks/projects/XML/src/main/royale/XML.as
@@ -2348,6 +2348,7 @@ package
 				if((_children[i] as XML).getNodeRef() == ELEMENT)
 					(_children[i] as XML).removeNamespace(ns);
 			}
+			xml$_notify("namespaceRemoved", this, ns, null);
 			return this;
 		}
 		

--- a/frameworks/projects/XML/src/main/royale/XML.as
+++ b/frameworks/projects/XML/src/main/royale/XML.as
@@ -2812,7 +2812,8 @@ package
 				//optimization, the name alone is sufficient to get the nodeKind() externally (see : getNodeRef())
 				delete this._nodeKind;
 			}
-			xml$_notify("nameSet", (ref == ATTRIBUTE ? _value : this), _name.toString(), oldName.toString());
+			// oldName cannot be null, normally, but we're calling setName() from within parseXMLStr() for processing instructions
+			if (oldName) xml$_notify("nameSet", (ref == ATTRIBUTE ? _value : this), _name.toString(), oldName.toString());
 		}
 		
 		/**

--- a/frameworks/projects/XML/src/main/royale/XML.as
+++ b/frameworks/projects/XML/src/main/royale/XML.as
@@ -3429,7 +3429,7 @@ package
 		public function xml$_notify(type:String, target:Object, value:Object, detail:Object):void
 		{
 			if (_internalSuppressNotify) return;
-			if (_notification) _notification(_notification, this, type, target, value, detail);
+			if (_notification) _notification(this, type, target, value, detail, _notification);
 			if (recursiveNotify && _parent) _parent.xml$_notify(type, target, value, detail);
 		}
 
@@ -3441,12 +3441,13 @@ package
 		/**
 		 * Callback function for change notification:
 		 *
-		 *   function xmlNotificationEx(callee:Function,
+		 *   function xmlNotificationEx(
 		 *     currentTarget:Object, 
 		 *     type:String, 
 		 *     target:Object, 
 		 *     value:Object, 
-		 *     detail:Object):void
+		 *     detail:Object,
+		 *     callee:Function = null):void
 		 *
 		 * type
 		 *

--- a/frameworks/projects/XML/src/main/royale/XML.as
+++ b/frameworks/projects/XML/src/main/royale/XML.as
@@ -797,12 +797,12 @@ package
 			if(child.getNodeRef() == ATTRIBUTE)
 			{
 				getAttributes().push(child);
-				xml$_notify("attributeAdded", "", child.localName(), child.getValue());
+				xml$_notify("attributeAdded", "", child.name(), child.getValue());
 			}
 			else
 			{
 				getChildren().push(child);
-				xml$_notify("nodeAdded", this, "", null);
+				xml$_notify("nodeAdded", this, new XML(), null);
 			}
 		}
 		
@@ -990,7 +990,7 @@ package
 			if (isAttribute)
 				xml$_notify("attributeAdded", "", child, null);
 			else
-				xml$_notify("nodeAdded", this, "", null);
+				xml$_notify("nodeAdded", this, new XML(), null);
 		}
 		
 		/**
@@ -1706,7 +1706,7 @@ package
 			child.setParent(this);
 			
 			getChildren().splice(idx,0,child);
-			xml$_notify("nodeAdded", this, "", null);
+			xml$_notify("nodeAdded", this, new XML(), null);
 		}
 		/**
 		 * Inserts the given child2 parameter after the child1 parameter in this XML object and returns the resulting object.

--- a/frameworks/projects/XML/src/main/royale/XML.as
+++ b/frameworks/projects/XML/src/main/royale/XML.as
@@ -2106,6 +2106,7 @@ package
 		 * @param child
 		 * @return
 		 *
+		 * @royaleignorecoercion QName
 		 */
 		public function removeChild(child:XML):Boolean
 		{
@@ -2159,7 +2160,8 @@ package
 						removed = _attributes[i];
 						removed._parent = null;
 						_attributes.splice(i,1);
-						xml$_notify("attributeRemoved", this, removed._name.toString(), removed._value);
+						// "_name as QName" (and ignorecoercion) needed to avoid compiler from writing ".child()" due to "removed" being XML
+						xml$_notify("attributeRemoved", this, (removed._name as QName).localName, removed._value);
 						return true;
 					}
 				}
@@ -2177,6 +2179,7 @@ package
 		/**
 		 *
 		 * @royaleignorecoercion XML
+		 * @royaleignorecoercion QName
 		 */
 		private function removeChildByName(name:*):Boolean
 		{
@@ -2197,7 +2200,8 @@ package
 						child._parent = null;
 						_attributes.splice(i,1);
 						removedItem = true;
-						xml$_notify("attributeRemoved", this, child._name.toString(), child._value);
+						// "_name as QName" (and ignorecoercion) needed to avoid compiler from writing ".child()" due to "child" being XML
+						xml$_notify("attributeRemoved", this, (child._name as QName).localName, child._value);
 					}
 				}
 				return removedItem;

--- a/frameworks/projects/XML/src/main/royale/XML.as
+++ b/frameworks/projects/XML/src/main/royale/XML.as
@@ -2734,8 +2734,11 @@ package
 				elements = elements + ''; //13.b
 				if (elements) {
 					y.replaceChildAt(0, elements); //13.c
-					// @todo get XML version of firstChildStr without parsing (but xmlFromStringable is not right)
-					y.xml$_notify("textSet", y._children[0], elements, new XML(firstChildStr));
+					if (_notification || (recursiveNotify && _parent))
+					{
+						// @todo get XML version of firstChildStr without parsing (but xmlFromStringable is not right)
+						y.xml$_notify("textSet", y._children[0], elements, new XML(firstChildStr));
+					}
 				}
 			} else {
 				//elements = (elements as XML).copy(); //@todo check... might need attention here

--- a/frameworks/projects/XML/src/main/royale/XML.as
+++ b/frameworks/projects/XML/src/main/royale/XML.as
@@ -2813,7 +2813,7 @@ package
 				delete this._nodeKind;
 			}
 			// oldName cannot be null, normally, but we're calling setName() from within parseXMLStr() for processing instructions
-			if (oldName) xml$_notify("nameSet", (ref == ATTRIBUTE ? _value : this), _name.toString(), oldName.toString());
+			if (oldName) xml$_notify("nameSet", (ref == ATTRIBUTE ? _value : this), (name is QName ? _name : _name.toString()), oldName.toString());
 		}
 		
 		/**

--- a/frameworks/projects/XML/src/main/royale/XML.as
+++ b/frameworks/projects/XML/src/main/royale/XML.as
@@ -3503,13 +3503,13 @@ package
 		 *   nodeRemoved
 		 *   namespaceAdded
 		 *   namespaceSet
+		 *   namespaceRemoved
 		 *   nameSet
 		 *   textSet
 		 *
 		 *   NOT IMPLEMENTED YET:
 		 *
 		 *   nodeChanged
-		 *   namespaceRemoved
 		 */
 
 		public function setNotification(callback:Function):void


### PR DESCRIPTION
1.  Needed to enumerate an ObjectMap, but WeakMap doesn't have enumeration.  So added a constructor option to force Map to be used instead of WeakMap if enumeration is needed (thought it would be better than subclassing just for that option), and implemented forEach().  Choose forEach() due to the wider browser support, over iteration.  Didn't implement forEach() for the really old browsers.

2.  Implemented the JS side of XMLNotifier.  XMLNotifier multiplexes XML notifications.  A complication is that JS doesn't have arguments.callee due to strict, so added an extra first arg to the internal notification function that communicates between XML and XMLNotifier, only on JS (for SWF, still uses the original method).

3.  Implemented many (but not all) XML notifications for JS.  They are sent for the current node only if setNotification() was called.  For the bubbling-up of notifications through the parent, need to set static XML.recursiveNotify = true (it is disabled by default).  Tested JS notification behavior against Flex, for a few levels of nodes and attributes.  Have not tested complex QNames.
