### PR TITLE
Fix various issues with Spark List and dynamic dataProvider

### DIFF
--- a/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/beads/layouts/VirtualListVerticalLayout.as
+++ b/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/beads/layouts/VirtualListVerticalLayout.as
@@ -77,10 +77,17 @@ package org.apache.royale.html.beads.layouts
         {
             super.strand = value;
             dataProviderModel = host.getBeadByType(IDataProviderModel) as IDataProviderModel;
+            dataProviderModel.addEventListener("dataProviderChanged", dataProviderChangeHandler);
+
             COMPILE::JS
             {
             host.element.addEventListener("scroll", scrollHandler);
             }
+        }
+
+        protected function dataProviderChangeHandler(event:Event):void
+        {
+            visibleIndexes = [];
         }
         
         COMPILE::JS

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/controls/beads/layouts/AdvancedDataGridVirtualListVerticalLayout.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/controls/beads/layouts/AdvancedDataGridVirtualListVerticalLayout.as
@@ -71,11 +71,11 @@ package mx.controls.beads.layouts
         {
             super.strand = value;
             (IStrandWithPresentationModel(value).presentationModel as DataGridPresentationModel).virtualized = true;
-            dataProviderModel.addEventListener("dataProviderChanged", dataProviderChangeHandler);
         }
         
-        private function dataProviderChangeHandler(event:Event):void
+        override protected function dataProviderChangeHandler(event:Event):void
         {
+            super.dataProviderChangeHandler(event);
             var factory:IDataProviderVirtualItemRendererMapper = host.getBeadByType(IDataProviderVirtualItemRendererMapper) as IDataProviderVirtualItemRendererMapper;
             while (visibleIndexes.length)
             {

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/controls/listClasses/VirtualDataItemRendererFactoryForICollectionViewData.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/controls/listClasses/VirtualDataItemRendererFactoryForICollectionViewData.as
@@ -125,6 +125,7 @@ package mx.controls.listClasses
             var dataGroup:IItemRendererOwnerView = view.dataGroup;
             
             dataGroup.removeAllItemRenderers();
+            rendererMap = {};
         }
         
 

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/controls/listClasses/VirtualDataItemRendererFactoryForIListData.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/controls/listClasses/VirtualDataItemRendererFactoryForIListData.as
@@ -120,6 +120,7 @@ package mx.controls.listClasses
             var dataGroup:IItemRendererOwnerView = view.dataGroup;
             
             dataGroup.removeAllItemRenderers();
+            rendererMap = {};
 			IEventDispatcher(_strand).dispatchEvent(new Event("layoutNeeded"));
 			
         }

--- a/frameworks/projects/SparkRoyale/src/main/resources/spark-royale-manifest.xml
+++ b/frameworks/projects/SparkRoyale/src/main/resources/spark-royale-manifest.xml
@@ -135,6 +135,7 @@
     <component id="GlowFilter" class="spark.filters.GlowFilter"/>
     <component id="Ellipse" class="spark.primitives.Ellipse"/>
     <component id="SparkButtonSkin" class="spark.skins.SparkButtonSkin"/>
+    <component id="CollectionChangeUpdateForArrayListData" class="spark.components.beads.CollectionChangeUpdateForArrayListData" />
 
 	
 </componentPackage>

--- a/frameworks/projects/SparkRoyale/src/main/royale/SparkRoyaleClasses.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/SparkRoyaleClasses.as
@@ -94,6 +94,7 @@ internal class SparkRoyaleClasses
     import spark.components.beads.SkinnableContainerView; SkinnableContainerView;
     import spark.components.beads.SparkSkinScrollingViewport; SparkSkinScrollingViewport;
 	import spark.components.beads.SparkSkinWithClipAndEnableScrollingViewport; SparkSkinWithClipAndEnableScrollingViewport;
+    import spark.components.beads.CollectionChangeUpdateForArrayListData; CollectionChangeUpdateForArrayListData;
     import spark.components.beads.DropDownListView; DropDownListView;
     import spark.components.beads.TitleWindowView; TitleWindowView;
     import spark.components.beads.controllers.DropDownListController; DropDownListController;

--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/beads/CollectionChangeUpdateForArrayListData.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/beads/CollectionChangeUpdateForArrayListData.as
@@ -1,0 +1,160 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+package spark.components.beads
+{
+	import org.apache.royale.core.IBead;
+	import org.apache.royale.core.IDataProviderModel;
+	import org.apache.royale.core.ISelectionModel;
+	import org.apache.royale.core.IStrand;
+	import org.apache.royale.core.IViewport;
+	import org.apache.royale.events.Event;
+	import org.apache.royale.events.IEventDispatcher;
+	import org.apache.royale.utils.sendBeadEvent;
+	import mx.events.CollectionEvent;
+	import spark.components.DataGroup;
+
+
+    /**
+	 *  Handles the update of an itemRenderer in a List component once the corresponding
+	 *  datum has been updated from the IDataProviderModel.
+	 *
+	 *  @langversion 3.0
+	 *  @playerversion Flash 10.2
+	 *  @playerversion AIR 2.6
+	 *  @productversion Royale 0.9.4
+	 */
+	public class CollectionChangeUpdateForArrayListData implements IBead
+	{
+		/**
+		 *  Constructor
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10.2
+		 *  @playerversion AIR 2.6
+		 *  @productversion Royale 0.9.4
+		 */
+		public function CollectionChangeUpdateForArrayListData()
+		{
+		}
+
+		protected var _strand:IStrand;
+
+        protected var labelField:String;
+
+		/**
+		 *  @copy org.apache.royale.core.IStrand
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10.2
+		 *  @playerversion AIR 2.6
+		 *  @productversion Royale 0.9.4
+		 *  @royaleignorecoercion org.apache.royale.events.IEventDispatcher
+		 */
+		public function set strand(value:IStrand):void
+		{
+			_strand = value;
+			IEventDispatcher(value).addEventListener("initComplete", initComplete);
+		}
+
+		/**
+		 *  finish setup
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10.2
+		 *  @playerversion AIR 2.6
+		 *  @productversion Royale 0.9.4
+		 *  @royaleignorecoercion org.apache.royale.events.IEventDispatcher
+		 *  @royaleignorecoercion org.apache.royale.core.IDataProviderModel
+		 */
+		protected function initComplete(event:Event):void
+		{
+			IEventDispatcher(_strand).removeEventListener("initComplete", initComplete);
+
+			var contentView : DataGroup = (_strand.getBeadByType(IViewport) as IViewport).contentView as DataGroup;
+			_dataProviderModel = contentView.getBeadByType(IDataProviderModel) as IDataProviderModel;
+			labelField = _dataProviderModel.labelField;
+
+			dataProviderModel.addEventListener("dataProviderChanged", dataProviderChangeHandler);
+
+			// invoke now in case "dataProviderChanged" has already been dispatched.
+			dataProviderChangeHandler(null);
+		}
+
+		private var dp:IEventDispatcher;
+		private var ignoreDPChange:Boolean;
+		/**
+		 * @private
+		 * @royaleignorecoercion org.apache.royale.events.IEventDispatcher
+		 */
+		protected function dataProviderChangeHandler(event:Event):void
+		{
+			if (ignoreDPChange) return;
+			if(dp)
+			{
+				dp.removeEventListener(CollectionEvent.COLLECTION_CHANGE, handleCollectionChange);
+			}
+			dp = dataProviderModel.dataProvider as IEventDispatcher;
+			if (!dp)
+				return;
+
+			// listen for COLLECTION_CHANGED in the future.
+			dp.addEventListener(CollectionEvent.COLLECTION_CHANGE, handleCollectionChange);
+		}
+
+		/**
+		 *  Handles the COLLECTION_CHANGED event by refreshing the full set of renderers.
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10.2
+		 *  @playerversion AIR 2.6
+		 *  @productversion Royale 0.9.4
+		 *  @royaleignorecoercion org.apache.royale.events.IEventDispatcher
+         *  @royaleignorecoercion org.apache.royale.core.ISelectionModel
+		 */
+		protected function handleCollectionChange(event:CollectionEvent):void
+		{
+			ignoreDPChange = true;
+			//simulate a dataProvider change (full renderer refresh)
+			sendBeadEvent(_dataProviderModel,"dataProviderChanged");
+			ignoreDPChange = false;
+		}
+
+		private var _dataProviderModel:IDataProviderModel;
+
+		/**
+		 *  The org.apache.royale.core.IDataProviderModel that contains the
+		 *  data source.
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10.2
+		 *  @playerversion AIR 2.6
+		 *  @productversion Royale 0.9.4
+		 *  @royaleignorecoercion org.apache.royale.core.IDataProviderModel
+		 */
+		public function get dataProviderModel():IDataProviderModel
+		{
+			if (_dataProviderModel == null) {
+				var contentView : DataGroup = (_strand.getBeadByType(IViewport) as IViewport).contentView as DataGroup;
+				_dataProviderModel = contentView.getBeadByType(IDataProviderModel) as IDataProviderModel;
+			}
+			return _dataProviderModel;
+		}
+		
+	}
+}


### PR DESCRIPTION
Fixed several issues that made Spark List unusable with dynamically-changing dataProviders:

o Fixed rendering problems in Basic VirtualListVerticalLayout (used by Spark List) and MX VirtualDataItemRendererFactoryForXX classes, because they weren't updating various things on dataProviderChange.

o Ported CollectionChangeUpdateForArrayListData bead to Spark, so Spark List can update on collection changes.

```
<s:List ...>
  <s:bead>
    <s:CollectionChangeUpdateForArrayListData />
  </s:bead>
</s:List>
```
