### PR TITLE
Fix MX Tree display problems with dynamic dataProvider, and implement Tree.isItemOpen()

### DIFF
--- a/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/beads/DataItemRendererFactoryForCollectionView.as
+++ b/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/beads/DataItemRendererFactoryForCollectionView.as
@@ -151,7 +151,7 @@ package org.apache.royale.html.beads
 		 */
 		protected function itemUpdatedHandler(event:CollectionEvent):void
 		{
-			if(dataProviderExist)
+			if(!dataProviderExist)
 				return;
 
 			var view:IListView = (_strand as IStrandWithModelView).view as IListView;

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/controls/Tree.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/controls/Tree.as
@@ -1706,12 +1706,10 @@ public class Tree extends List
      */
     public function isItemOpen(item:Object):Boolean
     {
-        trace("Tree:isItemOpen not implemented");
-        /*
+        // dataProvider (HierarchicalCollectionView) is maintaining this, through a reference to openItems;
+        // if it wasn't, could still create a bead to maintain it, to avoid an O(n) search for the itemRenderer.listData
         var uid:String = itemToUID(item);
         return _openItems[uid] != null;
-        */
-        return false;
     }
 
     /**

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/controls/treeClasses/DataItemRendererFactoryForICollectionViewHierarchicalData.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/controls/treeClasses/DataItemRendererFactoryForICollectionViewHierarchicalData.as
@@ -78,6 +78,8 @@ package mx.controls.treeClasses
 			super();
 		}
 
+		private var dp:ICollectionView;
+		
         /**
          * @private
          * @royaleignorecoercion mx.collections.ICollectionView
@@ -97,10 +99,11 @@ package mx.controls.treeClasses
 
             super.dataProviderChangeHandler(event);
 
-            var dped:IEventDispatcher = dataProviderModel.dataProvider as IEventDispatcher;
-            if (dped)
+            dp = dataProviderModel.dataProvider as ICollectionView;
+
+            if (dp)
             {
-                dped.addEventListener(mx.events.CollectionEvent.COLLECTION_CHANGE, collectionChangeHandler);
+                dp.addEventListener(mx.events.CollectionEvent.COLLECTION_CHANGE, collectionChangeHandler);
             }
         }
 
@@ -121,7 +124,6 @@ package mx.controls.treeClasses
         // assumes will be called in a loop, not random access
         override protected function get dataProviderLength():int
         {
-            var dp:ICollectionView = dataProviderModel.dataProvider as ICollectionView;
             cursor = dp.createCursor();
             return dp.length;
         }

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/controls/treeClasses/DataItemRendererFactoryForICollectionViewHierarchicalData.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/controls/treeClasses/DataItemRendererFactoryForICollectionViewHierarchicalData.as
@@ -21,6 +21,7 @@ package mx.controls.treeClasses
 	import mx.collections.ICollectionView;
     import mx.collections.IViewCursor;
     import mx.collections.ICollectionView;
+    import mx.collections.ListCollectionView;
     import mx.events.CollectionEvent;
     import mx.events.CollectionEventKind;
 	
@@ -112,7 +113,26 @@ package mx.controls.treeClasses
             {
                 if (event.kind == mx.events.CollectionEventKind.RESET)
                 {
+                    // RESET may be from XMLListCollection source = newxmlllist + refresh(), for example.
                     sendBeadEvent(dataProviderModel, "dataProviderChanged");
+                }
+                else if (event.kind == CollectionEventKind.ADD)
+                {
+                    // ADD may be from HierarchicalCollectionView.xmlNotification
+                    var addEvent:org.apache.royale.events.CollectionEvent 
+                        = new org.apache.royale.events.CollectionEvent(org.apache.royale.events.CollectionEvent.ITEM_ADDED);
+                    addEvent.item = event.items[0];
+                    addEvent.index = event.location;
+                    itemAddedHandler(addEvent);
+                }
+                else if (event.kind == CollectionEventKind.REMOVE)
+                {
+                    // REMOVE may be from HierarchicalCollectionView.xmlNotification
+                    var removeEvent:org.apache.royale.events.CollectionEvent 
+                        = new org.apache.royale.events.CollectionEvent(org.apache.royale.events.CollectionEvent.ITEM_REMOVED);
+                    removeEvent.item = event.items[0];
+                    removeEvent.index = event.location;
+                    itemRemovedHandler(removeEvent);
                 }
             }
         }

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/controls/treeClasses/DataItemRendererFactoryForICollectionViewHierarchicalData.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/controls/treeClasses/DataItemRendererFactoryForICollectionViewHierarchicalData.as
@@ -97,9 +97,8 @@ package mx.controls.treeClasses
                 dp.removeEventListener(mx.events.CollectionEvent.COLLECTION_CHANGE, collectionChangeHandler);
             }
 
-            super.dataProviderChangeHandler(event);
-
             dp = dataProviderModel.dataProvider as ICollectionView;
+            super.dataProviderChangeHandler(event);
 
             if (dp)
             {


### PR DESCRIPTION
 Fixed display problems in MX Tree when dataProvider is XMLListCollection and you do:

```
mydp.source = mynewxmllist;
mydp.refresh();
```

Also implemented Tree.isItemOpen().
