### PR TITLE
Hard-code (English) error messages in mx.messaging until resource bundles are worked out

### DIFF
--- a/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/AbstractConsumer.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/AbstractConsumer.as
@@ -359,8 +359,9 @@ public class AbstractConsumer extends MessageAgent
         {
             if (value < 0)
             {
-                var message:String = resourceManager.getString(
-                    "messaging", "resubscribeIntervalNegative");
+                /* var message:String = resourceManager.getString(
+                    "messaging", "resubscribeIntervalNegative"); */
+                var message:String = "resubscribeInterval cannot take a negative value.";
                 throw new ArgumentError(message);
             }
             else if (value == 0)
@@ -929,10 +930,12 @@ public class AbstractConsumer extends MessageAgent
             _shouldBeSubscribed = false;
             var errMsg:ErrorMessage = new ErrorMessage();
             errMsg.faultCode = "Client.Error.Subscribe";
-            errMsg.faultString = resourceManager.getString(
+            /* errMsg.faultString = resourceManager.getString(
                 "messaging", "consumerSubscribeError");
             errMsg.faultDetail = resourceManager.getString(
-                "messaging", "failedToSubscribe");
+                "messaging", "failedToSubscribe"); */
+            errMsg.faultString = "Consumer subscribe error";
+            errMsg.faultDetail = "The consumer was not able to subscribe to its target destination.";
             errMsg.correlationId = _subscribeMsg.messageId;
             fault(errMsg, _subscribeMsg);
             return;

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/AbstractProducer.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/AbstractProducer.as
@@ -350,8 +350,9 @@ public class AbstractProducer extends MessageAgent
         {
             if (value < 0)
             {
-                var message:String = resourceManager.getString(
-                    "messaging", "reconnectIntervalNegative");
+                /* var message:String = resourceManager.getString(
+                    "messaging", "reconnectIntervalNegative"); */
+                var message:String = "reconnectInterval cannot take a negative value.";
                 throw new ArgumentError(message);
             }
             else if (value == 0)
@@ -556,10 +557,12 @@ public class AbstractProducer extends MessageAgent
             _shouldBeConnected = false;
             var errMsg2:ErrorMessage = new ErrorMessage();
             errMsg2.faultCode = "Client.Error.MessageSend";
-            errMsg2.faultString = resourceManager.getString(
+            /* errMsg2.faultString = resourceManager.getString(
                 "messaging", "producerSendError");
             errMsg2.faultDetail = resourceManager.getString(
-                "messaging", "producerSendErrorDetails");
+                "messaging", "producerSendErrorDetails"); */
+            errMsg2.faultString = "Send failed";
+            errMsg2.faultDetail = "The producer is not connected and the message cannot be sent.";
             errMsg2.correlationId = message.messageId;
             internalFault(errMsg2, message, false, true);
         }        
@@ -732,10 +735,12 @@ public class AbstractProducer extends MessageAgent
     {
         var errMsg:ErrorMessage = new ErrorMessage();
         errMsg.faultCode = "Client.Error.Connect";
-        errMsg.faultString = resourceManager.getString(
+        /* errMsg.faultString = resourceManager.getString(
             "messaging", "producerConnectError");
         errMsg.faultDetail = resourceManager.getString(
-            "messaging", "failedToConnect");
+            "messaging", "failedToConnect"); */
+        errMsg.faultString = "Producer connect error";
+        errMsg.faultDetail = "The producer was not able to connect to its target destination.";
         errMsg.correlationId = _connectMsg.messageId;
         return errMsg;
     }

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/ChannelSet.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/ChannelSet.as
@@ -424,8 +424,9 @@ public class ChannelSet extends EventDispatcher
     {
         if (configured)
         {
-            var message:String = resourceManager.getString(
-                "messaging", "cannotAddWhenConfigured");
+            /* var message:String = resourceManager.getString(
+                "messaging", "cannotAddWhenConfigured"); */
+            var message:String = "Channels cannot be added to a ChannelSet that targets a configured destination.";
             throw new IllegalOperationError(message);
         }
 
@@ -663,8 +664,9 @@ public class ChannelSet extends EventDispatcher
                 {
                     if (ids[i] == null)
                     {
-                        var message:String = resourceManager.getString(
-                            "messaging", "cannotSetClusteredWithdNullChannelIds");
+                        /* var message:String = resourceManager.getString(
+                            "messaging", "cannotSetClusteredWithdNullChannelIds"); */
+                        var message:String = "Cannot change clustered property of ChannelSet to true when it contains channels with null ids.";
                         throw new IllegalOperationError(message);
                     }
                 }
@@ -852,15 +854,17 @@ public class ChannelSet extends EventDispatcher
 
         if (configured)
         {
-            message = resourceManager.getString(
-                "messaging", "cannotAddWhenConfigured");
+            /* message = resourceManager.getString(
+                "messaging", "cannotAddWhenConfigured"); */
+            message = "Channels cannot be added to a ChannelSet that targets a configured destination.";
             throw new IllegalOperationError(message);
         }
 
         if (clustered && channel.id == null)
         {
-            message = resourceManager.getString(
-                "messaging", "cannotAddNullIdChannelWhenClustered");
+            /* message = resourceManager.getString(
+                "messaging", "cannotAddNullIdChannelWhenClustered"); */
+            message = "Cannot add a channel with null id to ChannelSet when its clustered property is true.";
             throw new IllegalOperationError(message);
         }
 
@@ -892,8 +896,9 @@ public class ChannelSet extends EventDispatcher
     {
         if (configured)
         {
-            var message:String = resourceManager.getString(
-                "messaging", "cannotRemoveWhenConfigured");
+            /* var message:String = resourceManager.getString(
+                "messaging", "cannotRemoveWhenConfigured"); */
+            var message:String = "Channels cannot be removed from a ChannelSet that targets a configured destination.";
             throw new IllegalOperationError(message);
         }
 
@@ -1610,8 +1615,9 @@ public class ChannelSet extends EventDispatcher
             errorMsg.correlationId = pendingMsg.messageId;
             errorMsg.headers[ErrorMessage.RETRYABLE_HINT_HEADER] = true;
             errorMsg.faultCode = "Client.Error.MessageSend";
-            errorMsg.faultString = resourceManager.getString(
-                "messaging", "sendFailed");
+            /* errorMsg.faultString = resourceManager.getString(
+                "messaging", "sendFailed"); */
+            errorMsg.faultString = "Send failed";
             if (event is ChannelFaultEvent)
             {
                 var faultEvent:ChannelFaultEvent = event as ChannelFaultEvent;
@@ -1628,8 +1634,9 @@ public class ChannelSet extends EventDispatcher
             // being able to connect at all.
             else
             {
-                errorMsg.faultDetail = resourceManager.getString(
-                    "messaging", "cannotConnectToDestination");
+                /* errorMsg.faultDetail = resourceManager.getString(
+                    "messaging", "cannotConnectToDestination"); */
+                errorMsg.faultDetail = "No connection could be made to the message destination.";
             }
             errorMsg.rootCause = event;
             ps.agent.fault(errorMsg, pendingMsg);
@@ -1762,8 +1769,9 @@ public class ChannelSet extends EventDispatcher
     {
         if (_channels.length == 0)
         {
-            var message:String = resourceManager.getString(
-                "messaging", "noAvailableChannels");
+            /* var message:String = resourceManager.getString(
+                "messaging", "noAvailableChannels"); */
+            var message:String = "No Channels are available for use.";
             throw new NoChannelAvailableError(message);
         }
 

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/MessageResponder.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/MessageResponder.as
@@ -304,10 +304,12 @@ public class MessageResponder extends Responder
         var errorMsg:ErrorMessage = new ErrorMessage();
         errorMsg.correlationId = message.messageId;
         errorMsg.faultCode = "Client.Error.RequestTimeout";
-        errorMsg.faultString = resourceManager.getString(
+        /* errorMsg.faultString = resourceManager.getString(
             "messaging", "requestTimedOut");
         errorMsg.faultDetail = resourceManager.getString(
-            "messaging", "requestTimedOut.details");
+            "messaging", "requestTimedOut.details"); */
+        errorMsg.faultString = "Request timed out";
+        errorMsg.faultDetail = "The request timeout for the sent message was reached without receiving a response from the server.";
         return errorMsg;
     }
 

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/channels/DirectHTTPChannel.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/channels/DirectHTTPChannel.as
@@ -92,8 +92,9 @@ package mx.messaging.channels
 			super(id, uri);
 			if (uri.length > 0)
 			{
-				var message:String = resourceManager.getString(
-					"messaging", "noURIAllowed");
+				/* var message:String = resourceManager.getString(
+					"messaging", "noURIAllowed"); */
+				var message:String = "Error for DirectHTTPChannel. No URI can be specified.";
 				throw new InvalidChannelError(message);
 			}
 			clientId = ("DirectHTTPChannel" + clientCounter++);
@@ -309,8 +310,9 @@ package mx.messaging.channels
 		
 		override public function setCredentials(credentials:String, agent:MessageAgent=null, charset:String=null):void
 		{
-			var message:String = resourceManager.getString(
-				"messaging", "authenticationNotSupported");
+			/* var message:String = resourceManager.getString(
+				"messaging", "authenticationNotSupported"); */
+			var message:String = "Authentication not supported on DirectHTTPChannel (no proxy).";
 			throw new ChannelError(message);
 		}
 		
@@ -353,6 +355,7 @@ import mx.messaging.messages.ErrorMessage;
 import mx.messaging.messages.IMessage;
 import mx.resources.IResourceManager;
 import mx.resources.ResourceManager;
+import mx.utils.StringUtil;  // temp until resource bundles worked out
 
 use namespace mx_internal;
 
@@ -442,16 +445,18 @@ class DirectHTTPMessageResponder extends MessageResponder
 		msg.clientId = clientId;
 		msg.correlationId = message.messageId;
 		msg.faultCode = "Server.Error.Request";
-		msg.faultString = resourceManager.getString(
-			"messaging", "httpRequestError");
+		/* msg.faultString = resourceManager.getString(
+			"messaging", "httpRequestError"); */
+		msg.faultString = "HTTP request error";
 		var details:String = event.toString();
 		if (message is HTTPRequestMessage)
 		{
 			details += ". URL: ";
 			details += HTTPRequestMessage(message).url;
 		}
-		msg.faultDetail = resourceManager.getString(
-			"messaging", "httpRequestError.details", [ details ]);
+		/* msg.faultDetail = resourceManager.getString(
+			"messaging", "httpRequestError.details", [ details ]); */
+		msg.faultDetail = StringUtil.substitute("Error: {0}", details);
 		msg.rootCause = event;
 		msg.body = URLLoader(event.target).data;
 		msg.headers[AbstractMessage.STATUS_CODE_HEADER] = lastStatus;
@@ -475,10 +480,12 @@ class DirectHTTPMessageResponder extends MessageResponder
 		msg.clientId = clientId;
 		msg.correlationId = message.messageId;
 		msg.faultCode = "Channel.Security.Error";
-		msg.faultString = resourceManager.getString(
+		/* msg.faultString = resourceManager.getString(
 			"messaging", "securityError");
 		msg.faultDetail = resourceManager.getString(
-			"messaging", "securityError.details", [ message.destination ]);
+			"messaging", "securityError.details", [ message.destination ]); */
+		msg.faultString = "Security error accessing url";
+		msg.faultDetail = StringUtil.substitute("Destination: {0}", message.destination);
 		msg.rootCause = event;
 		msg.body = URLLoader(event.target).data;
 		msg.headers[AbstractMessage.STATUS_CODE_HEADER] = lastStatus;

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/channels/HTTPChannel.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/channels/HTTPChannel.as
@@ -840,16 +840,18 @@ class HTTPWrapperResponder
         var msg:ErrorMessage = new ErrorMessage();
         msg.correlationId = _wrappedResponder.message.messageId;
         msg.faultCode = "Server.Error.Request";
-        msg.faultString = resourceManager.getString(
-            "messaging", "httpRequestError");
+        /* msg.faultString = resourceManager.getString(
+            "messaging", "httpRequestError"); */
+        msg.faultString = "HTTP request error";
         var details:String = event.toString();
         if (_wrappedResponder.message is HTTPRequestMessage)
         {
             details += ". URL: ";
             details += HTTPRequestMessage(_wrappedResponder.message).url;
         }
-        msg.faultDetail = resourceManager.getString(
-            "messaging", "httpRequestError.details", [ details ]);
+        /* msg.faultDetail = resourceManager.getString(
+            "messaging", "httpRequestError.details", [ details ]); */
+        msg.faultDetail = StringUtil.substitute("Error: {0}", details);
         msg.rootCause = event;
         _wrappedResponder.status(msg);
     }
@@ -949,11 +951,14 @@ class HTTPMessageResponder extends MessageResponder
             {
                 errorMsg = new ErrorMessage();
                 errorMsg.faultCode = "Server.Acknowledge.Failed";
-                errorMsg.faultString = resourceManager.getString(
+                /* errorMsg.faultString = resourceManager.getString(
                     "messaging", "ackFailed");
                 errorMsg.faultDetail = resourceManager.getString(
                     "messaging", "ackFailed.details",
-                    [ message.messageId, AsyncMessage(response).correlationId ]);
+                    [ message.messageId, AsyncMessage(response).correlationId ]); */
+                errorMsg.faultString = "Didn't receive an acknowledgement of message";
+                errorMsg.faultDetail = StringUtil.substitute("Was expecting message '{0}' but received '{1}'.",
+                    message.messageId, AsyncMessage(response).correlationId);
                 agent.fault(errorMsg, message);
             }
         }
@@ -961,11 +966,14 @@ class HTTPMessageResponder extends MessageResponder
         {
             errorMsg = new ErrorMessage();
             errorMsg.faultCode = "Server.Acknowledge.Failed";
-            errorMsg.faultString = resourceManager.getString(
+            /* errorMsg.faultString = resourceManager.getString(
                 "messaging", "noAckMessage");
             errorMsg.faultDetail = resourceManager.getString(
                 "messaging", "noAckMessage.details",
-                [ mx.utils.ObjectUtil.toString(response) ]);
+                [ mx.utils.ObjectUtil.toString(response) ]); */
+            errorMsg.faultString = "Didn't receive an acknowledge message";
+            errorMsg.faultDetail = StringUtil.substitute("Was expecting mx.messaging.messages.AcknowledgeMessage, but received {0}",
+                mx.utils.ObjectUtil.toString(response));
             agent.fault(errorMsg, message);
         }
     }
@@ -1027,16 +1035,18 @@ class HTTPMessageResponder extends MessageResponder
         var msg:ErrorMessage = new ErrorMessage();
         msg.correlationId = message.messageId;
         msg.faultCode = "Server.Error.Request";
-        msg.faultString = resourceManager.getString(
-            "messaging", "httpRequestError");
+        /* msg.faultString = resourceManager.getString(
+            "messaging", "httpRequestError"); */
+        msg.faultString = "HTTP request error";
         var details:String = event.toString();
         if (message is HTTPRequestMessage)
         {
             details += ". URL: ";
             details += HTTPRequestMessage(message).url;
         }
-        msg.faultDetail = resourceManager.getString(
-            "messaging", "httpRequestError.details", [ details ]);
+        /* msg.faultDetail = resourceManager.getString(
+            "messaging", "httpRequestError.details", [ details ]); */
+        msg.faultDetail = StringUtil.substitute("Error: {0}", details);
         msg.rootCause = event;
         agent.fault(msg, message);
     }
@@ -1056,16 +1066,18 @@ class HTTPMessageResponder extends MessageResponder
         var msg:ErrorMessage = new ErrorMessage();
         msg.correlationId = message.messageId;
         msg.faultCode = "Server.Error.Request";
-        msg.faultString = resourceManager.getString(
-            "messaging", "httpRequestError");
+        /* msg.faultString = resourceManager.getString(
+            "messaging", "httpRequestError"); */
+        msg.faultString = "HTTP request error";
         var details:String = event.toString();
         if (message is HTTPRequestMessage)
         {
             details += ". URL: ";
             details += HTTPRequestMessage(message).url;
         }
-        msg.faultDetail = resourceManager.getString(
-            "messaging", "httpRequestError.details", [ details ]);
+        /* msg.faultDetail = resourceManager.getString(
+            "messaging", "httpRequestError.details", [ details ]); */
+        msg.faultDetail = StringUtil.substitute("Error: {0}", details);
         msg.rootCause = event;
 
         (channel as HTTPChannel).connectionError(msg);
@@ -1090,10 +1102,12 @@ class HTTPMessageResponder extends MessageResponder
         var msg:ErrorMessage = new ErrorMessage();
         msg.correlationId = message.messageId;
         msg.faultCode = "Channel.Security.Error";
-        msg.faultString = resourceManager.getString(
+        /* msg.faultString = resourceManager.getString(
             "messaging", "securityError");
         msg.faultDetail = resourceManager.getString(
-            "messaging", "securityError.details", [ message.destination ]);
+            "messaging", "securityError.details", [ message.destination ]); */
+        msg.faultString = "Security error accessing url";
+        msg.faultDetail = StringUtil.substitute("Destination: {0}", message.destination);
         msg.rootCause = event;
         agent.fault(msg, message);
     }

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/channels/NetConnectionChannel.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/messaging/channels/NetConnectionChannel.as
@@ -586,11 +586,14 @@ class NetConnectionMessageResponder extends MessageResponder
             {
                 errorMsg = new ErrorMessage();
                 errorMsg.faultCode = "Server.Acknowledge.Failed";
-                errorMsg.faultString = resourceManager.getString(
+                /* errorMsg.faultString = resourceManager.getString(
                     "messaging", "ackFailed");
                 errorMsg.faultDetail = resourceManager.getString(
                     "messaging", "ackFailed.details",
-                    [ message.messageId, AsyncMessage(msg).correlationId ]);
+                    [ message.messageId, AsyncMessage(msg).correlationId ]); */
+                errorMsg.faultString = "Didn't receive an acknowledgement of message";
+                errorMsg.faultDetail = StringUtil.substitute("Was expecting message '{0}' but received '{1}'.",
+                    message.messageId, AsyncMessage(msg).correlationId);
                 errorMsg.correlationId = message.messageId;
                 agent.fault(errorMsg, message);
                 //@TODO: need to add constants here
@@ -600,11 +603,14 @@ class NetConnectionMessageResponder extends MessageResponder
         {
             errorMsg = new ErrorMessage();
             errorMsg.faultCode = "Server.Acknowledge.Failed";
-            errorMsg.faultString = resourceManager.getString(
+            /* errorMsg.faultString = resourceManager.getString(
                 "messaging", "noAckMessage");
             errorMsg.faultDetail = resourceManager.getString(
                 "messaging", "noAckMessage.details",
-                [ msg ? msg.toString() : "null" ]);
+                [ msg ? msg.toString() : "null" ]); */
+            errorMsg.faultString = "Didn't receive an acknowledge message";
+            errorMsg.faultDetail = StringUtil.substitute("Was expecting mx.messaging.messages.AcknowledgeMessage, but received {0}",
+                msg ? msg.toString() : "null");
             errorMsg.correlationId = message.messageId;
             agent.fault(errorMsg, message);
         }
@@ -649,11 +655,14 @@ class NetConnectionMessageResponder extends MessageResponder
             {
                 errorMsg = new ErrorMessage();
                 errorMsg.faultCode = "Server.Acknowledge.Failed";
-                errorMsg.faultString = resourceManager.getString(
+                /* errorMsg.faultString = resourceManager.getString(
                     "messaging", "noErrorForMessage");
                 errorMsg.faultDetail = resourceManager.getString(
                     "messaging", "noErrorForMessage.details",
-                    [ message.messageId, AsyncMessage(msg).correlationId ]);
+                    [ message.messageId, AsyncMessage(msg).correlationId ]); */
+                errorMsg.faultString = "Didn't receive an error for message";
+                errorMsg.faultDetail = StringUtil.substitute("Was expecting message '{0}' but received '{1}'.",
+                    message.messageId, AsyncMessage(msg).correlationId);
                 errorMsg.correlationId = message.messageId;
                 agent.fault(errorMsg, message);
             }
@@ -662,11 +671,14 @@ class NetConnectionMessageResponder extends MessageResponder
         {
             errorMsg = new ErrorMessage();
             errorMsg.faultCode = "Server.Acknowledge.Failed";
-            errorMsg.faultString = resourceManager.getString(
+            /* errorMsg.faultString = resourceManager.getString(
                 "messaging", "noAckMessage");
             errorMsg.faultDetail = resourceManager.getString(
                 "messaging", "noAckMessage.details",
-                [ msg ? msg.toString(): "null" ]);
+                [ msg ? msg.toString(): "null" ]); */
+            errorMsg.faultString = "Didn't receive an acknowledge message";
+            errorMsg.faultDetail = StringUtil.substitute("Was expecting mx.messaging.messages.AcknowledgeMessage, but received {0}",
+                msg ? msg.toString(): "null");
             errorMsg.correlationId = message.messageId;
             agent.fault(errorMsg, message);
         }
@@ -711,10 +723,12 @@ class NetConnectionMessageResponder extends MessageResponder
         disconnect();
         var errorMsg:ErrorMessage = new ErrorMessage();
         errorMsg.correlationId = message.messageId;
-        errorMsg.faultString = resourceManager.getString(
+        /* errorMsg.faultString = resourceManager.getString(
             "messaging", "deliveryInDoubt");
         errorMsg.faultDetail = resourceManager.getString
-            ("messaging", "deliveryInDoubt.details");
+            ("messaging", "deliveryInDoubt.details"); */
+        errorMsg.faultString = "Channel disconnected";
+        errorMsg.faultDetail = "Channel disconnected before an acknowledgement was received";
         errorMsg.faultCode = ErrorMessage.MESSAGE_DELIVERY_IN_DOUBT;
         errorMsg.rootCause = event;
         agent.fault(errorMsg, message);


### PR DESCRIPTION
So that meaningful messages are returned on failures instead of blank strings.