### PR TITLE
Measure (especially height) properly for Spark Label when width is explicitly set

### DIFF
--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/Label.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/Label.as
@@ -1709,7 +1709,8 @@ public class Label extends TextBase
     {
         //when measuring, turn off wrapping
         var oldValue:String = element.style.whiteSpace;
-        element.style.whiteSpace = "nowrap";
+        if ((isNaN(explicitWidth) && isNaN(percentWidth)) || getStyle("lineBreak") == "explicit")
+	        element.style.whiteSpace = "nowrap";
         var mw:Number = super.measuredWidth;
         element.style.whiteSpace = oldValue;
         return mw + 1;
@@ -1720,7 +1721,8 @@ public class Label extends TextBase
     {
         //when measuring, turn off wrapping
         var oldValue:String = element.style.whiteSpace;
-        element.style.whiteSpace = "nowrap";
+        if ((isNaN(explicitWidth) && isNaN(percentWidth)) || getStyle("lineBreak") == "explicit")
+	        element.style.whiteSpace = "nowrap";
         var mh:Number = super.measuredHeight;
         element.style.whiteSpace = oldValue;
         return mh;


### PR DESCRIPTION
(Wrapping occurs only when width/percentWidth is explicitly set and style lineBreak != explicit.)
