### PR TITLE
Implement Spark SkinnableDataContainer, reconfigure DataGroup, adjust List, and add SelfItemRendererInitializer

### DIFF
--- a/frameworks/projects/SparkRoyale/src/main/resources/defaults.css
+++ b/frameworks/projects/SparkRoyale/src/main/resources/defaults.css
@@ -68,6 +68,19 @@ Image
 
 DataGroup
 {
+	IDataProviderItemRendererMapper: ClassReference("mx.controls.listClasses.DataItemRendererFactoryForIListData");
+	IBeadModel: ClassReference("mx.controls.beads.models.SingleSelectionIListModel");
+	IBeadView:  ClassReference("org.apache.royale.html.beads.DataContainerView");			
+	IBeadLayout: ClassReference("spark.layouts.supportClasses.SparkLayoutBead");
+	IItemRendererClassFactory: ClassReference("org.apache.royale.core.ItemRendererClassFactory");
+	IItemRenderer: ClassReference("spark.components.beads.SelfItemRenderer");
+	IItemRendererInitializer: ClassReference("spark.components.beads.SelfItemRendererInitializer");
+	IViewport: ClassReference("org.apache.royale.html.supportClasses.ScrollingViewport");
+	IViewportModel: ClassReference("org.apache.royale.html.beads.models.ViewportModel");
+}
+
+VirtualVDataGroup
+{
 	IDataProviderItemRendererMapper: ClassReference("mx.controls.listClasses.VirtualDataItemRendererFactoryForIListData");
 	IBeadModel: ClassReference("mx.controls.beads.models.SingleSelectionIListModel");
 	IBeadView:  ClassReference("org.apache.royale.html.beads.VirtualListView");			
@@ -90,12 +103,13 @@ NonVirtualHDataGroup
 	IBeadLayout: ClassReference("spark.layouts.HorizontalLayout");
 	IItemRendererClassFactory: ClassReference("org.apache.royale.core.SelectableItemRendererClassFactory");
 	IItemRenderer: ClassReference("spark.components.supportClasses.SparkTextButtonItemRenderer");
-	IItemRendererInitializer: ClassReference("org.apache.royale.html.beads.ListItemRendererInitializer");
+	IItemRendererInitializer: ClassReference("mx.controls.beads.ListItemRendererInitializer");
 	ISelectableItemRenderer: ClassReference("org.apache.royale.html.beads.SolidBackgroundSelectableItemRendererBead");
 	IViewport: ClassReference("org.apache.royale.html.supportClasses.ScrollingViewport");
 	IViewportModel: ClassReference("org.apache.royale.html.beads.models.ViewportModel");
 }
 
+/* not used
 NonVirtualVDataGroup
 {
 	IDataProviderItemRendererMapper: ClassReference("mx.controls.listClasses.DataItemRendererFactoryForIListData");
@@ -104,12 +118,12 @@ NonVirtualVDataGroup
 	IBeadController: ClassReference("org.apache.royale.html.beads.controllers.ListSingleSelectionMouseController");
 	IBeadLayout: ClassReference("org.apache.royale.html.beads.layouts.VerticalLayout");
 	IItemRendererClassFactory: ClassReference("org.apache.royale.core.SelectableItemRendererClassFactory");
+	IItemRenderer: ClassReference("mx.controls.listClasses.ListItemRenderer");
 	IItemRendererInitializer: ClassReference("mx.controls.beads.ListItemRendererInitializer");
 	ISelectableItemRenderer: ClassReference("org.apache.royale.html.beads.SolidBackgroundSelectableItemRendererBead");
-	IItemRenderer: ClassReference("mx.controls.listClasses.ListItemRenderer");
 	IViewport: ClassReference("org.apache.royale.html.supportClasses.ScrollingViewport");
 	IViewportModel: ClassReference("org.apache.royale.html.beads.models.ViewportModel");
-}
+} */
 
 DropDownList
 {
@@ -140,7 +154,7 @@ List
 	IBeadLayout: ClassReference("spark.layouts.supportClasses.SparkLayoutBead");
 	IViewport: ClassReference("org.apache.royale.html.supportClasses.ScrollingViewport");
 	IViewportModel: ClassReference("org.apache.royale.html.beads.models.ViewportModel");
-	IContentView: ClassReference("spark.components.DataGroup");
+	IContentView: ClassReference("spark.components.VirtualVDataGroup");
 }
 
 NumericStepper
@@ -187,6 +201,16 @@ SkinnableContainer
 	IViewport: ClassReference("spark.components.beads.SparkSkinScrollingViewport");
 	IViewportModel: ClassReference("org.apache.royale.html.beads.models.ViewportModel");
 	IContentView: ClassReference("spark.components.Group");
+	border-width: 1px;
+}
+
+SkinnableDataContainer
+{
+	IBeadView: ClassReference("spark.components.beads.SkinnableDataContainerView");
+	IBeadLayout: ClassReference("spark.layouts.supportClasses.SparkLayoutBead");
+	IViewport: ClassReference("spark.components.beads.SparkSkinScrollingViewport");
+	IViewportModel: ClassReference("org.apache.royale.html.beads.models.ViewportModel");
+	IContentView: ClassReference("spark.components.DataGroup");
 	border-width: 1px;
 }
 
@@ -273,6 +297,13 @@ TitleWindow
 	    IBorderBead: ClassReference("org.apache.royale.html.beads.SingleLineBorderBead");
 	    IContentView: ClassReference("org.apache.royale.html.supportClasses.ContainerContentArea");
     }
+
+	SkinnableDataContainer
+	{
+		IBackgroundBead: ClassReference("org.apache.royale.html.beads.SolidBackgroundBead");
+		IBorderBead: ClassReference("org.apache.royale.html.beads.SingleLineBorderBead");
+		IContentView: ClassReference("org.apache.royale.html.supportClasses.DataGroup");
+	}
 
 	Label
 	{

--- a/frameworks/projects/SparkRoyale/src/main/resources/spark-royale-manifest.xml
+++ b/frameworks/projects/SparkRoyale/src/main/resources/spark-royale-manifest.xml
@@ -46,6 +46,7 @@
 	<component id="Skin" class="spark.components.supportClasses.Skin"/>
 	<component id="SkinnableComponent" class="spark.components.supportClasses.SkinnableComponent"/>
     <component id="SkinnableContainer" class="spark.components.SkinnableContainer"/>
+    <component id="SkinnableDataContainer" class="spark.components.SkinnableDataContainer"/>
 	<component id="ToggleButton" class="spark.components.ToggleButton"/>
 	<component id="ToggleButtonBase" class="spark.components.supportClasses.ToggleButtonBase"/>
 	<component id="ButtonBase" class="spark.components.supportClasses.ButtonBase"/>
@@ -117,6 +118,7 @@
 	<component id="ButtonBar" class="spark.components.ButtonBar"/>
 	<component id="SkinnablePopUpContainer" class="spark.components.SkinnablePopUpContainer"/>
     
+    <component id="VirtualVDataGroup" class="spark.components.VirtualVDataGroup"/>
     <component id="NonVirtualHDataGroup" class="spark.components.NonVirtualHDataGroup"/>
     <component id="NonVirtualVDataGroup" class="spark.components.NonVirtualVDataGroup"/>
     <component id="TabBarView" class="spark.components.beads.TabBarView"/>
@@ -137,6 +139,8 @@
     <component id="SparkButtonSkin" class="spark.skins.SparkButtonSkin"/>
     <component id="Graphic" class="spark.primitives.Graphic"/>
     <component id="Move" class="spark.effects.Move"/>
+    <component id="SelfItemRenderer" class="spark.components.beads.SelfItemRenderer"/>
+    <component id="SelfItemRendererInitializer" class="spark.components.beads.SelfItemRendererInitializer"/>
 
 	
 </componentPackage>

--- a/frameworks/projects/SparkRoyale/src/main/royale/SparkRoyaleClasses.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/SparkRoyaleClasses.as
@@ -92,6 +92,7 @@ internal class SparkRoyaleClasses
     import spark.components.beads.PanelView; PanelView;
     import spark.components.beads.GroupView; GroupView;
     import spark.components.beads.SkinnableContainerView; SkinnableContainerView;
+    import spark.components.beads.SkinnableDataContainerView; SkinnableDataContainerView;
     import spark.components.beads.SparkSkinScrollingViewport; SparkSkinScrollingViewport;
 	import spark.components.beads.SparkSkinWithClipAndEnableScrollingViewport; SparkSkinWithClipAndEnableScrollingViewport;
     import spark.components.beads.DropDownListView; DropDownListView;
@@ -103,7 +104,6 @@ internal class SparkRoyaleClasses
 
 	
 import spark.components.IItemRenderer; IItemRenderer;
-//import spark.components.SkinnableDataContainer; SkinnableDataContainer;
 //import spark.components.VideoDisplay; VideoDisplay;
 //import spark.components.mediaClasses.ScrubBar; ScrubBar;
 //import spark.components.mediaClasses.VolumeBar; VolumeBar;

--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/SkinnableDataContainer.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/SkinnableDataContainer.as
@@ -20,22 +20,45 @@
 package spark.components
 {
 
-import org.apache.royale.events.Event;
-
 import mx.collections.IList;
 import mx.core.IDataRenderer;
 import mx.core.IFactory;
+import mx.core.IUIComponent;
 import mx.core.IVisualElement;
 import mx.core.mx_internal;
 import mx.events.PropertyChangeEvent;
 import mx.utils.BitFlagUtil;
 
 import spark.components.supportClasses.SkinnableContainerBase;
+import spark.components.supportClasses.GroupBase;
+import spark.components.beads.SkinnableDataContainerView;
+import spark.components.beads.SparkDataContainerView;
 import spark.core.IViewport;
-import spark.events.RendererExistenceEvent;
+//import spark.events.RendererExistenceEvent;
 import spark.layouts.supportClasses.LayoutBase;
 
 use namespace mx_internal;
+
+import org.apache.royale.core.IBead;
+import org.apache.royale.core.IItemRendererProvider;
+import org.apache.royale.core.IStrandWithPresentationModel;
+import org.apache.royale.core.IListPresentationModel;
+import org.apache.royale.html.beads.models.ListPresentationModel;
+
+import org.apache.royale.binding.ContainerDataBinding;
+import org.apache.royale.binding.DataBindingBase;
+import org.apache.royale.core.IBeadLayout;
+import org.apache.royale.core.IBeadView;
+import org.apache.royale.core.IChild;
+import org.apache.royale.core.ILayoutHost;
+import org.apache.royale.core.IParent;
+import org.apache.royale.core.ItemRendererClassFactory;
+import org.apache.royale.core.ValuesManager;
+import org.apache.royale.events.Event;
+import org.apache.royale.events.IEventDispatcher;
+import org.apache.royale.events.ValueEvent;
+import org.apache.royale.utils.loadBeadFromValuesManager;
+
 
 /**
  *  Dispatched when a renderer is added to the container.
@@ -49,7 +72,7 @@ use namespace mx_internal;
  *  @playerversion AIR 1.5
  *  @productversion Flex 4
  */
-[Event(name="rendererAdd", type="spark.events.RendererExistenceEvent")]
+//[Event(name="rendererAdd", type="spark.events.RendererExistenceEvent")]
 
 /**
  *  Dispatched when a renderer is removed from the container.
@@ -63,7 +86,7 @@ use namespace mx_internal;
  *  @playerversion AIR 1.5
  *  @productversion Flex 4
  */
-[Event(name="rendererRemove", type="spark.events.RendererExistenceEvent")]
+//[Event(name="rendererRemove", type="spark.events.RendererExistenceEvent")]
 
 //include "../styles/metadata/BasicInheritingTextStyles.as"
 
@@ -204,10 +227,10 @@ use namespace mx_internal;
  *  @langversion 3.0
  *  @playerversion Flash 10
  *  @playerversion AIR 1.5
- *  @productversion Flex 4
+ *  @productversion Royale 0.9.8
  */
-public class SkinnableDataContainer extends SkinnableContainerBase implements IItemRendererOwner
-{
+public class SkinnableDataContainer extends SkinnableContainerBase implements IItemRendererProvider, IStrandWithPresentationModel
+{ //implements IItemRendererOwner
     //include "../core/Version.as";
     
     //--------------------------------------------------------------------------
@@ -258,12 +281,49 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
      *  @langversion 3.0
      *  @playerversion Flash 10
      *  @playerversion AIR 1.5
-     *  @productversion Flex 4
+     *  @productversion Royale 0.9.8
      */
     public function SkinnableDataContainer()
     {
         super();
+        typeNames = "SkinnableDataContainer";
     }
+
+
+    /**
+     * Returns the ILayoutHost which is its view. From ILayoutParent.
+     *
+     *  @langversion 3.0
+     *  @playerversion Flash 10.2
+     *  @playerversion AIR 2.6
+     *  @productversion Royale 0.8
+     */
+    public function getLayoutHost():ILayoutHost
+    {
+        return view as ILayoutHost;
+    }
+
+    
+    /**
+     *  The presentation model for the list.
+     *
+     *  @langversion 3.0
+     *  @playerversion Flash 10.2
+     *  @playerversion AIR 2.6
+     *  @productversion Royale 0.9
+     *  @royaleignorecoercion org.apache.royale.core.IListPresentationModel
+     */
+    public function get presentationModel():IBead
+    {
+        var presModel:IListPresentationModel = getBeadByType(IListPresentationModel) as IListPresentationModel;
+        if (presModel == null) {
+            presModel = new ListPresentationModel();
+            presModel.rowHeight = 18;
+            addBead(presModel);
+        }
+        return presModel;
+    }
+
     
     //--------------------------------------------------------------------------
     //
@@ -283,7 +343,7 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
      *  @playerversion AIR 1.5
      *  @productversion Flex 4
      */
-    public var dataGroup:DataGroup;
+    //public var dataGroup:DataGroup;
     
     /**
      *  @private
@@ -302,7 +362,7 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
      *  dataGroupProperties stores booleans as to whether these properties 
      *  have been explicitly set or not.
      */
-    private var dataGroupProperties:Object = {};
+    //private var dataGroupProperties:Object = {};
     
     //--------------------------------------------------------------------------
     //
@@ -320,7 +380,7 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
     //  autoLayout
     //----------------------------------
 
-    [Inspectable(defaultValue="true")]
+    //[Inspectable(defaultValue="true")]
 
     /**
      *  @copy spark.components.supportClasses.GroupBase#autoLayout
@@ -332,7 +392,7 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
      *  @playerversion AIR 1.5
      *  @productversion Flex 4
      */
-    public function get autoLayout():Boolean
+    /* public function get autoLayout():Boolean
     {
         if (dataGroup)
             return dataGroup.autoLayout;
@@ -342,12 +402,12 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
             var v:* = dataGroupProperties.autoLayout;
             return (v === undefined) ? true : v;
         }
-    }
+    } */
 
     /**
      *  @private
      */
-    public function set autoLayout(value:Boolean):void
+    /* public function set autoLayout(value:Boolean):void
     {
         if (dataGroup)
         {
@@ -358,7 +418,7 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
         else
             dataGroupProperties.autoLayout = value;
     }
-    
+     */
     //----------------------------------
     //  dataProvider
     //----------------------------------    
@@ -376,21 +436,31 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
      *  @langversion 3.0
      *  @playerversion Flash 10
      *  @playerversion AIR 1.5
-     *  @productversion Flex 4
+     *  @productversion Royale 0.9.8
+     * 
+     *  @royaleignorecoercion spark.components.DataGroup
+     *  @royaleignorecoercion spark.components.beads.SparkDataContainerView
      */
     [Bindable("dataProviderChanged")]
     [Inspectable(category="Data")]
     
     public function get dataProvider():IList
     {       
-        return (dataGroup) 
+        /* return (dataGroup) 
             ? dataGroup.dataProvider 
-            : dataGroupProperties.dataProvider;
+            : dataGroupProperties.dataProvider; */
+
+        return ((view as SparkDataContainerView).contentView as DataGroup).dataProvider;
     }
     
+    /**
+     *  @private
+     *  @royaleignorecoercion spark.components.DataGroup
+     *  @royaleignorecoercion spark.components.beads.SparkDataContainerView
+     */
     public function set dataProvider(value:IList):void
     {
-        if (dataGroup)
+        /* if (dataGroup)
         {
             dataGroup.dataProvider = value;
             dataGroupProperties = BitFlagUtil.update(dataGroupProperties as uint, 
@@ -398,7 +468,27 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
         }
         else
             dataGroupProperties.dataProvider = value;
-        dispatchEvent(new Event("dataProviderChanged"));
+        dispatchEvent(new Event("dataProviderChanged")); */
+
+        if (isWidthSizedToContent() || isHeightSizedToContent())
+            ((view as SparkDataContainerView).contentView as DataGroup).addEventListener("itemsCreated", itemsCreatedHandler);
+        ((view as SparkDataContainerView).contentView as DataGroup).dataProvider = value;
+    }
+
+    private function itemsCreatedHandler(event:Event):void
+    {
+        if (parent)
+        {
+            COMPILE::JS
+            {
+                // clear last width/height so elements size to content
+                element.style.width = "";
+                element.style.height = "";
+                ((view as SparkDataContainerView).contentView as DataGroup).element.style.width = "";
+                ((view as SparkDataContainerView).contentView as DataGroup).element.style.height = "";
+            }
+            (parent as IEventDispatcher).dispatchEvent(new Event("layoutNeeded"));
+        }
     }
     
     //----------------------------------
@@ -413,28 +503,39 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
      *  @langversion 3.0
      *  @playerversion Flash 10
      *  @playerversion AIR 1.5
-     *  @productversion Flex 4
+     *  @productversion Royale 0.9.8
      */
+    [SWFOverride(returns="org.apache.royale.core.IFactory")]
     public function get itemRenderer():IFactory
     {
-        return (dataGroup) 
+        /* return (dataGroup) 
             ? dataGroup.itemRenderer 
-            : dataGroupProperties.itemRenderer;
+            : dataGroupProperties.itemRenderer; */
+
+        return ((view as SparkDataContainerView).contentView as DataGroup).itemRenderer;
     }
     
     /**
      *  @private
      */
+    [SWFOverride(params="org.apache.royale.core.IFactory", altparams="mx.core.IFactory")]
     public function set itemRenderer(value:IFactory):void
     {
-        if (dataGroup)
+        /* if (dataGroup)
         {
             dataGroup.itemRenderer = value;
             dataGroupProperties = BitFlagUtil.update(dataGroupProperties as uint, 
                                                      ITEM_RENDERER_PROPERTY_FLAG, true);
         }
         else
-            dataGroupProperties.itemRenderer = value;
+            dataGroupProperties.itemRenderer = value; */
+
+        ((view as SparkDataContainerView).contentView as DataGroup).itemRenderer = value;
+        // the ItemRendererFactory was already put on the DataGroup's strand and
+        // determined which factory to use so we have to set it up later here.
+        var factory:ItemRendererClassFactory = ((view as SparkDataContainerView).contentView as DataGroup).getBeadByType(ItemRendererClassFactory) as ItemRendererClassFactory;
+        factory.createFunction = factory.createFromClass;
+        factory.itemRendererFactory = value;
     }
     
     //----------------------------------
@@ -449,13 +550,15 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
      *  @langversion 3.0
      *  @playerversion Flash 10
      *  @playerversion AIR 1.5
-     *  @productversion Flex 4
+     *  @productversion Royale 0.9.8
      */
     public function get itemRendererFunction():Function
     {
-        return (dataGroup) 
+        /* return (dataGroup) 
             ? dataGroup.itemRendererFunction 
-            : dataGroupProperties.itemRendererFunction;
+            : dataGroupProperties.itemRendererFunction; */
+
+        return null;
     }
     
     /**
@@ -463,19 +566,21 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
      */
     public function set itemRendererFunction(value:Function):void
     {
-        if (dataGroup)
+        /* if (dataGroup)
         {
             dataGroup.itemRendererFunction = value;
             dataGroupProperties = BitFlagUtil.update(dataGroupProperties as uint, 
                                                      ITEM_RENDERER_FUNCTION_PROPERTY_FLAG, true);
         }
         else
-            dataGroupProperties.itemRendererFunction = value;
+            dataGroupProperties.itemRendererFunction = value; */
     }
     
     //----------------------------------
     //  layout
     //----------------------------------
+
+    private var _layout:LayoutBase;
     
     [Inspectable(category="General")]
     
@@ -487,20 +592,27 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
      *  @langversion 3.0
      *  @playerversion Flash 10
      *  @playerversion AIR 1.5
-     *  @productversion Flex 4
+     *  @productversion Royale 0.9.8
      */     
     public function get layout():LayoutBase
     {
-        return (dataGroup) 
+        /* return (dataGroup) 
             ? dataGroup.layout 
             : dataGroupProperties.layout;
+         */
+        //if (!_layout)
+        //    _layout = new BasicLayout();
+        return _layout;
     }
 
     /**
      *  @private
+     *  @royaleignorecoercion spark.components.GroupBase
+     *  @royaleignorecoercion spark.components.beads.SparkDataContainerView
      */
     public function set layout(value:LayoutBase):void
     {
+        /*
         if (dataGroup)
         {
             dataGroup.layout = value;
@@ -509,13 +621,21 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
         }
         else
             dataGroupProperties.layout = value;
+         */
+        _layout = value;
+        if (getBeadByType(IBeadView))
+        {
+            ((view as SkinnableDataContainerView).contentView as GroupBase).layout = value;
+            if (parent)
+                ((view as SkinnableDataContainerView).contentView as GroupBase).dispatchEvent(new Event("layoutNeeded"));       
+        }
     }
     
     //----------------------------------
     //  typicalItem
     //----------------------------------
 
-    [Inspectable(category="Data")]
+    //[Inspectable(category="Data")]
     
     /**
      *  @copy spark.components.DataGroup#typicalItem
@@ -525,17 +645,17 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
      *  @playerversion AIR 1.5
      *  @productversion Flex 4
      */
-    public function get typicalItem():Object
+    /* public function get typicalItem():Object
     {
         return (dataGroup) 
             ? dataGroup.typicalItem 
             : dataGroupProperties.typicalItem;
-    }
+    } */
 
     /**
      *  @private
      */
-    public function set typicalItem(value:Object):void
+    /* public function set typicalItem(value:Object):void
     {
         if (dataGroup)
         {
@@ -545,7 +665,7 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
         }
         else
             dataGroupProperties.typicalItem = value;
-    }
+    } */
     
     //--------------------------------------------------------------------------
     //
@@ -567,7 +687,7 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
      *  @langversion 3.0
      *  @playerversion Flash 10
      *  @playerversion AIR 1.5
-     *  @productversion Flex 4
+     *  @productversion Royale 0.9.8
      */
     public function itemToLabel(item:Object):String
     {
@@ -596,7 +716,7 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
      *  @productversion Flex 4
      * 
      */
-    public function updateRenderer(renderer:IVisualElement, itemIndex:int, data:Object):void
+    /* public function updateRenderer(renderer:IVisualElement, itemIndex:int, data:Object):void
     {
         // set the owner
         renderer.owner = this;
@@ -613,7 +733,7 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
         if ((renderer is IDataRenderer) && (renderer !== data))
             IDataRenderer(renderer).data = data;
     }
-
+     */
     //--------------------------------------------------------------------------
     //
     //  Overridden methods
@@ -627,7 +747,7 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
     {
         super.partAdded(partName, instance);
 
-        if (instance == dataGroup)
+        /* if (instance == dataGroup)
         {
             // copy proxied values from dataGroupProperties (if set) to dataGroup
             
@@ -694,7 +814,7 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
                 dataGroup.addEventListener(
                     RendererExistenceEvent.RENDERER_REMOVE, dispatchEvent);
             }
-        }
+        } */
     }
     
     /**
@@ -702,7 +822,7 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
      */
     override protected function partRemoved(partName:String, instance:Object):void
     {
-        super.partRemoved(partName, instance);
+        /* super.partRemoved(partName, instance);
 
         if (instance == dataGroup)
         {
@@ -738,7 +858,7 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
             dataGroup.dataProvider = null;
             dataGroup.layout = null;
             dataGroup.rendererUpdateDelegate = null;
-        }
+        } */
     }
     
     /**
@@ -748,7 +868,7 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
      *  for property change events.  If no one's listening for them, then we don't 
      *  listen for them on our dataGroup.
      */
-    override public function addEventListener(
+    /* override public function addEventListener(
         type:String, listener:Function, useCapture:Boolean=false, priority:int=0, useWeakReference:Boolean=false) : void
     {
         super.addEventListener(type, listener, useCapture, priority, useWeakReference);
@@ -772,7 +892,7 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
             dataGroup.addEventListener(
                 RendererExistenceEvent.RENDERER_REMOVE, dispatchEvent);
         }
-    }
+    } */
     
     /**
      *  @private
@@ -781,7 +901,7 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
      *  for property change events.  If no one's listening for them, then we don't 
      *  listen for them on our dataGroup.
      */
-    override public function removeEventListener(type:String, listener:Function, useCapture:Boolean=false) : void
+    /* override public function removeEventListener(type:String, listener:Function, useCapture:Boolean=false) : void
     {
         super.removeEventListener(type, listener, useCapture);
         
@@ -804,7 +924,76 @@ public class SkinnableDataContainer extends SkinnableContainerBase implements II
                     RendererExistenceEvent.RENDERER_REMOVE, dispatchEvent);
             }
         }
+    } */
+
+    //--------------------------------------------------------------------------
+    //
+    //  Overridden methods
+    //
+    //--------------------------------------------------------------------------
+
+    //--------------------------------------------------------------------------
+    //
+    //  IMXMLDocument et al
+    //
+    //--------------------------------------------------------------------------
+    
+    private var _mxmlDescriptor:Array;
+    private var _mxmlDocument:Object = this;
+
+    /**
+     *  @private
+     *  @royaleignorecoercion spark.components.DataGroup
+     *  @royaleignorecoercion spark.components.beads.SparkDataContainerView
+     */
+    override public function addedToParent():void
+    {
+//        if (!getBeadByType(IBeadLayout))
+//            addBead(new VerticalLayout());
+
+        if (!initialized) {
+            // each MXML file can also have styles in fx:Style block
+            ValuesManager.valuesImpl.init(this);
+        }
+
+        super.addedToParent();
+
+        // Load the layout bead if it hasn't already been loaded.
+        loadBeadFromValuesManager(IBeadLayout, "iBeadLayout", this);
+
+        dispatchEvent(new Event("beadsAdded"));
+        dispatchEvent(new Event("initComplete"));
+        if ((isHeightSizedToContent() || !isNaN(explicitHeight)) &&
+            (isWidthSizedToContent() || !isNaN(explicitWidth)))
+            dispatchEvent(new Event("layoutNeeded"));
+
+//		((view as SparkDataContainerView).contentView as DataGroup).addEventListener("change", redispatcher);
+		((view as SparkDataContainerView).contentView as DataGroup).addEventListener("itemClick", redispatcher);
+		((view as SparkDataContainerView).contentView as DataGroup).addEventListener("doubleClick", redispatcher);
+		
+        setActualSize(getExplicitOrMeasuredWidth(), getExplicitOrMeasuredHeight());
     }
+
+    override protected function createChildren():void
+    {
+        super.createChildren();
+        
+        if (getBeadByType(DataBindingBase) == null)
+            addBead(new ContainerDataBinding());
+        
+        dispatchEvent(new Event("initBindings"));
+    }
+    
+    override public function setActualSize(w:Number, h:Number):void
+    {
+        super.setActualSize(w, h);
+        ((view as SparkDataContainerView).contentView as DataGroup).setActualSize(w, h);
+    }
+
+	private function redispatcher(event:Event):void
+	{
+		dispatchEvent(new Event(event.type));
+	}
 }
 
 }

--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/VirtualVDataGroup.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/VirtualVDataGroup.as
@@ -1,0 +1,49 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package spark.components
+{
+
+/**
+ *  The VirtualVDataGroup class is a DataGroup that defaults to
+ *  virtual vertical layout
+ *  
+ *  @langversion 3.0
+ *  @playerversion Flash 10
+ *  @playerversion AIR 1.5
+ *  @productversion Flex 4
+ */
+public class VirtualVDataGroup extends DataGroup
+{
+    /**
+     *  Constructor.
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 10
+     *  @playerversion AIR 1.5
+     *  @productversion Flex 4
+     */
+    public function VirtualVDataGroup()
+    {
+        super();
+        typeNames = "VirtualVDataGroup";
+        
+    }
+}
+}

--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/beads/SelfItemRenderer.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/beads/SelfItemRenderer.as
@@ -1,0 +1,52 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package spark.components.beads
+{
+	import spark.components.supportClasses.ItemRenderer;
+	import org.apache.royale.core.IBeadLayout;
+	import org.apache.royale.core.IIndexedItemRenderer;
+	import org.apache.royale.events.Event;
+
+	/**
+	 *  The SelfItemRenderer class defines the Spark item renderer class 
+	 *  these uses the item to render itself.
+	 *  
+	 *  @langversion 3.0
+	 *  @playerversion Flash 10
+	 *  @playerversion AIR 1.5
+	 *  @productversion Royale 0.9.8
+	 */
+	public class SelfItemRenderer extends ItemRenderer implements IIndexedItemRenderer
+	{    
+		/**
+		 *  Constructor.
+		 * 
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10
+		 *  @playerversion AIR 1.5
+		 *  @productversion Royale 0.9.8
+		 */
+		public function SelfItemRenderer()
+		{
+			super();
+			typeNames = "SelfItemRenderer";
+		}
+	}
+}

--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/beads/SelfItemRendererInitializer.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/beads/SelfItemRendererInitializer.as
@@ -1,0 +1,88 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package spark.components.beads
+{
+	import org.apache.royale.core.Bead;
+	import org.apache.royale.core.IChild;
+	import org.apache.royale.core.IItemRenderer;
+	import org.apache.royale.core.IIndexedItemRenderer;
+	import org.apache.royale.core.IItemRendererInitializer;
+	import org.apache.royale.core.IIndexedItemRendererInitializer;
+	import org.apache.royale.core.ILayoutChild;
+   
+	/**
+	 *  The SelfItemRendererInitializer class initializes self item renderers.
+	 *  
+	 *  @langversion 3.0
+	 *  @playerversion Flash 10.2
+	 *  @playerversion AIR 2.6
+	 *  @productversion Royale 0.9.8
+	 */
+	public class SelfItemRendererInitializer extends Bead implements IItemRendererInitializer, IIndexedItemRendererInitializer
+	{
+		/**
+		 *  Constructor.
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10.2
+		 *  @playerversion AIR 2.6
+		 *  @productversion Royale 0.9.8
+		 */
+		public function SelfItemRendererInitializer()
+		{
+		}
+
+		/**
+		 *  @private
+		 */
+		public function initializeItemRenderer(renderer:IItemRenderer, data:Object):void
+		{
+			var child:IChild = data as IChild;
+			if (child == null) return;
+		
+			var sir:SelfItemRenderer = renderer as SelfItemRenderer;
+			if (sir == null) return;
+			
+			var plc:ILayoutChild = sir.parent as ILayoutChild;
+			var clc:ILayoutChild = child as ILayoutChild;
+			if (plc && clc)
+			{
+				sir.explicitWidth = NaN;
+				sir.percentWidth = NaN;
+				if (!plc.isWidthSizedToContent() && !clc.isWidthSizedToContent()) sir.percentWidth = 100;
+				sir.explicitHeight = NaN;
+				sir.percentHeight = NaN;
+				if (!plc.isHeightSizedToContent() && !clc.isHeightSizedToContent()) sir.percentHeight = 100;
+				sir.invalidateSize();
+			}
+			
+			sir.removeAllElements();
+			sir.addElement(child);
+		}
+
+		/**
+		 *  @private
+		 */
+		public function initializeIndexedItemRenderer(renderer:IIndexedItemRenderer, data:Object, index:int):void
+		{
+			initializeItemRenderer(renderer, data);
+		}
+	}
+}

--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/beads/SkinnableDataContainerView.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/beads/SkinnableDataContainerView.as
@@ -1,0 +1,143 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package spark.components.beads
+{
+
+import spark.components.SkinnableDataContainer;
+import spark.components.supportClasses.GroupBase;
+import spark.components.supportClasses.SkinnableComponent;
+import spark.components.supportClasses.Skin;
+import spark.layouts.BasicLayout;
+
+import org.apache.royale.core.IBead;
+import org.apache.royale.core.IContainer;
+import org.apache.royale.core.ILayoutChild;
+import org.apache.royale.core.IStrand;
+import org.apache.royale.core.UIBase;
+
+/**
+ *  @private
+ *  The SkinnableDataContainerView for emulation.
+ */
+public class SkinnableDataContainerView extends SparkDataContainerView
+{
+	//--------------------------------------------------------------------------
+	//
+	//  Constructor
+	//
+	//--------------------------------------------------------------------------
+
+	/**
+	 *  Constructor.
+	 *  
+	 *  @langversion 3.0
+	 *  @playerversion Flash 9
+	 *  @playerversion AIR 1.1
+	 *  @productversion Flex 3
+	 */
+	public function SkinnableDataContainerView()
+	{
+		super();
+	}
+
+    override protected function prepareContentView():void
+    {
+        var host:SkinnableDataContainer = _strand as SkinnableDataContainer;
+        if (host.skin)
+        {
+            if (!host.isWidthSizedToContent())
+                host.skin.percentWidth = 100;
+            if (!host.isHeightSizedToContent())
+                host.skin.percentHeight = 100;            
+        }
+        else
+            super.prepareContentView();
+    }
+
+    /**
+     *  Adjusts the size of the host after the layout has been run if needed
+     *
+     *  @langversion 3.0
+     *  @playerversion Flash 10.2
+     *  @playerversion AIR 2.6
+     *  @productversion Royale 0.0
+     *  @royaleignorecoercion org.apache.royale.core.UIBase
+     */
+    override public function beforeLayout():Boolean
+    {
+        var host:SkinnableDataContainer = _strand as SkinnableDataContainer;
+        if (host.isWidthSizedToContent() && host.isHeightSizedToContent())
+        {
+            if (host.skin)
+            {
+                (host.skin as Skin).layout.measure();
+                host.measuredHeight = host.skin.measuredHeight;
+                host.measuredWidth = host.skin.measuredWidth;
+            }
+            else 
+            {
+                if (host.layout == null)
+                    host.layout = new BasicLayout();
+                host.layout.measure();
+            }
+        }
+        else
+        {
+            if (host.skin)
+            {
+			    (host.skin as Skin).layout.measure();
+			    if (host.isWidthSizedToContent()) 
+			    {
+				    host.skin.setLayoutBoundsSize(NaN, host.height);
+				    host.measuredWidth = host.skin.measuredWidth;
+			    } else
+			    {
+				    host.skin.setLayoutBoundsSize(host.width, NaN);
+				    host.measuredHeight = host.skin.measuredHeight;
+			    }
+            }
+            else
+            {
+                if (host.layout == null)
+                    host.layout = new BasicLayout();
+                host.layout.measure();
+				var h:Number = host.isHeightSizedToContent() ? host.measuredHeight : host.height;
+				var w:Number = host.isWidthSizedToContent() ? host.measuredWidth : host.width;
+                (viewport.contentView as ILayoutChild).setWidthAndHeight(w, h);
+            }
+                
+        }
+	return true;
+    }
+    
+    override protected function addViewport():void
+    {
+        var chost:IContainer = host as IContainer;
+        var skinhost:SkinnableComponent = host as SkinnableComponent;
+        if (chost != null && chost != viewport.contentView && skinhost.skin) {
+            chost.addElement(skinhost.skin);
+        }
+        else
+            super.addViewport();
+    }
+
+}
+
+}

--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/beads/SparkDataContainerView.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/beads/SparkDataContainerView.as
@@ -1,0 +1,130 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package spark.components.beads
+{
+
+import spark.components.SkinnableDataContainer;
+import spark.components.supportClasses.GroupBase;
+import spark.layouts.BasicLayout;
+
+import org.apache.royale.core.IBead;
+import org.apache.royale.core.IContainer;
+import org.apache.royale.core.ILayoutChild;
+import org.apache.royale.core.IStrand;
+import org.apache.royale.core.UIBase;
+import org.apache.royale.html.beads.ContainerView;
+import org.apache.royale.events.Event;
+import org.apache.royale.events.IEventDispatcher;
+
+/**
+ *  @private
+ *  The SparkDataContainerView for emulation.
+ */
+public class SparkDataContainerView extends ContainerView
+{
+	//--------------------------------------------------------------------------
+	//
+	//  Constructor
+	//
+	//--------------------------------------------------------------------------
+
+	/**
+	 *  Constructor.
+	 *  
+	 *  @langversion 3.0
+	 *  @playerversion Flash 9
+	 *  @playerversion AIR 1.1
+	 *  @productversion Flex 3
+	 */
+	public function SparkDataContainerView()
+	{
+		super();
+	}
+
+    /**
+     */
+    override public function set strand(value:IStrand):void
+    {
+        super.strand = value;
+        prepareContentView();
+    }
+    
+    protected function prepareContentView():void
+    {
+        var host:SkinnableDataContainer = _strand as SkinnableDataContainer;
+        var g:GroupBase = (contentView as GroupBase);
+        if (host.layout != null)
+            g.layout = host.layout;
+        if (g.layout == null)
+            g.layout = new BasicLayout();
+        
+        if (!host.isWidthSizedToContent())
+            g.percentWidth = 100;
+        if (!host.isHeightSizedToContent())
+            g.percentHeight = 100;
+
+    }
+    
+    /**
+     *  Adjusts the size of the host after the layout has been run if needed
+     *
+     *  @langversion 3.0
+     *  @playerversion Flash 10.2
+     *  @playerversion AIR 2.6
+     *  @productversion Royale 0.0
+     *  @royaleignorecoercion org.apache.royale.core.UIBase
+     */
+    override public function beforeLayout():Boolean
+    {
+        var host:SkinnableDataContainer = _strand as SkinnableDataContainer;
+        if (host.isWidthSizedToContent() || host.isHeightSizedToContent())
+        {
+            host.layout.measure();
+        }
+		return true;
+    }
+    
+    /**
+     *  Adjusts the size of the host after the layout has been run if needed
+     *
+     *  @langversion 3.0
+     *  @playerversion Flash 10.2
+     *  @playerversion AIR 2.6
+     *  @productversion Royale 0.0
+     *  @royaleignorecoercion org.apache.royale.core.UIBase
+     */
+    override public function afterLayout():void
+    {
+        var host:SkinnableDataContainer = _strand as SkinnableDataContainer;
+        if (host.isWidthSizedToContent() || host.isHeightSizedToContent())
+        {
+            // request re-run layout on the parent.  In theory, we should only
+            // end up in afterLayout if the content size changed.
+            if (host.parent)
+            {
+                (host.parent as IEventDispatcher).dispatchEvent(new Event("layoutNeeded"));   
+            }
+        }
+    }
+
+
+}
+
+}

--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/beads/SparkSkinScrollingViewport.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/beads/SparkSkinScrollingViewport.as
@@ -39,7 +39,6 @@ import org.apache.royale.core.ValuesManager;
 import org.apache.royale.events.Event;
 import org.apache.royale.events.EventDispatcher;
 import org.apache.royale.geom.Size;
-import spark.components.SkinnableContainer;
 
 COMPILE::SWF
 {

--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/beads/SparkSkinViewport.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/beads/SparkSkinViewport.as
@@ -37,6 +37,8 @@ import org.apache.royale.events.Event;
 import org.apache.royale.events.EventDispatcher;
 import org.apache.royale.geom.Size;
 import spark.components.SkinnableContainer;
+import spark.components.SkinnableDataContainer;
+import spark.layouts.supportClasses.LayoutBase;
 
 COMPILE::SWF
 {
@@ -96,7 +98,7 @@ public class SparkSkinViewport extends EventDispatcher implements IBead, IViewpo
         {
             host.setSkin(new c());
             host.skin.addEventListener("initComplete", initCompleteHandler);
-            contentArea = host.skin; // temporary assigment so that SkinnableContainer.addElement can add the skin
+            contentArea = host.skin; // temporary assigment so that SkinnableXXContainer.addElement can add the skin
         }
         else
         {
@@ -120,6 +122,12 @@ public class SparkSkinViewport extends EventDispatcher implements IBead, IViewpo
             if (sc.layout)
                 (contentArea as GroupBase).layout = sc.layout;       
         }
+        else if (host is SkinnableDataContainer)
+        {
+            var sdc:SkinnableDataContainer = host as SkinnableDataContainer;
+            if (sdc.layout)
+                (contentArea as GroupBase).layout = sdc.layout;
+        }
             
 		COMPILE::JS
 		{
@@ -137,23 +145,25 @@ public class SparkSkinViewport extends EventDispatcher implements IBead, IViewpo
     {
         if(host != contentArea)
         {
+            var scl:LayoutBase = null;
+
             if (host is SkinnableContainer)
             {
                 var sc:SkinnableContainer = host as SkinnableContainer;
-                if (sc.layout)
-                {
-                    if (!sc.layout.isWidthSizedToContent())
-                        contentArea.percentWidth = 100;
-                    if (!sc.layout.isHeightSizedToContent())
-                        contentArea.percentHeight = 100;
-                }
-                else
-                {
-                    if (host.isWidthSizedToContent())
-                        contentArea.percentWidth = 100;
-                    if (host.isHeightSizedToContent())
-                        contentArea.percentHeight = 100;                    
-                }
+                scl = sc.layout;
+            }
+            else if (host is SkinnableDataContainer)
+            {
+                var sdc:SkinnableDataContainer = host as SkinnableDataContainer;
+                scl = sdc.layout;
+            }
+
+            if (scl)
+            {
+                if (!scl.isWidthSizedToContent())
+                    contentArea.percentWidth = 100;
+                if (!scl.isHeightSizedToContent())
+                   contentArea.percentHeight = 100;
             }
             else
             {

--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/supportClasses/ListBase.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/supportClasses/ListBase.as
@@ -565,7 +565,7 @@ public class ListBase  extends SkinnableContainer
         factory.createFunction = factory.createFromClass;
         factory.itemRendererFactory = value;
     }
-    
+
 
     //----------------------------------
     //  itemRendererFunction
@@ -603,6 +603,7 @@ public class ListBase  extends SkinnableContainer
         //else
             //dataGroupProperties.itemRendererFunction = value;
     }
+
     /**
      *  @private
      */
@@ -1157,7 +1158,7 @@ public class ListBase  extends SkinnableContainer
      *  however in this case, always honoring the layout's useVirtalLayout property seems 
      *  less likely to cause confusion.
      */
-     public function set useVirtualLayout(value:Boolean):void
+    public function set useVirtualLayout(value:Boolean):void
     {
         if (value == useVirtualLayout)
             return;
@@ -1348,6 +1349,19 @@ public class ListBase  extends SkinnableContainer
                 RendererExistenceEvent.RENDERER_REMOVE, dataGroup_rendererRemoveHandler);
         }
     } */
+
+	//dataGroup copied from SkinnableDataContainer
+	/**
+     *  An optional skin part that defines the DataGroup in the skin class 
+     *  where data items get pushed into, rendered, and laid out.
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 10
+     *  @playerversion AIR 1.5
+     *  @productversion Royale 0.9.4
+     *  @royalesuppresspublicvarwarning
+     */
+    public var dataGroup:DataGroup;
 
     /**
      *  @private

--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/supportClasses/SkinnableComponent.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/supportClasses/SkinnableComponent.as
@@ -410,19 +410,6 @@ public class SkinnableComponent extends UIComponent
 
     protected function partRemoved(partName:String, instance:Object):void {} // not implemented
 
-	//dataGroup copied from SkinnableDataContainer
-	/**
-     *  An optional skin part that defines the DataGroup in the skin class 
-     *  where data items get pushed into, rendered, and laid out.
-     *  
-     *  @langversion 3.0
-     *  @playerversion Flash 10
-     *  @playerversion AIR 1.5
-     *  @productversion Royale 0.9.4
-     *  @royalesuppresspublicvarwarning
-     */
-    public var dataGroup:DataGroup;
-
 	// getCurrentSkinState copied from SkinnableContainerBase
 	/* override */ protected function getCurrentSkinState():String
     {

--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/layouts/HorizontalLayout.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/layouts/HorizontalLayout.as
@@ -25,7 +25,7 @@ import mx.core.IVisualElement;
 import mx.core.mx_internal;
 import mx.events.PropertyChangeEvent;
 
-import spark.components.DataGroup;
+//import spark.components.DataGroup;
 import spark.components.supportClasses.GroupBase;
 import spark.core.NavigationUnit;
 import spark.layouts.supportClasses.DropLocation;

--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/layouts/VerticalLayout.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/layouts/VerticalLayout.as
@@ -30,7 +30,7 @@ import mx.core.IVisualElement;
 import mx.core.mx_internal;
 import mx.events.PropertyChangeEvent;
 
-import spark.components.DataGroup;
+//import spark.components.DataGroup;
 import spark.components.supportClasses.GroupBase;
 import spark.core.NavigationUnit;
 import spark.layouts.supportClasses.DropLocation;

--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/layouts/supportClasses/SparkLayoutBead.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/layouts/supportClasses/SparkLayoutBead.as
@@ -27,6 +27,7 @@ import mx.core.mx_internal;
 
 import spark.components.supportClasses.GroupBase;
 import spark.components.SkinnableContainer;
+import spark.components.SkinnableDataContainer;
 import spark.core.NavigationUnit;
 
 import org.apache.royale.core.IBeadLayout;
@@ -88,6 +89,8 @@ public class SparkLayoutBead extends org.apache.royale.core.LayoutBase
 		var usingSkin:Boolean = false;
 		if (host is SkinnableContainer)
 			usingSkin = (host as SkinnableContainer).skin != null;
+		else if (host is SkinnableDataContainer)
+			usingSkin = (host as SkinnableDataContainer).skin != null;
 				
         if (!usingSkin && target != host)
         {


### PR DESCRIPTION
- Implemented Spark SkinnableDataContainer, which is basically a combination of DataGroup, List, and SkinnableContainer.

- Should use with DataGroup fix in #966 (not included in this pull request).

- Reconfigured CSS of DataGroup to implement more proper behavior.  For example, when DataGroup.itemRender = null, it can by default render VGroup and such.  It can also take different layouts.  The old CSS for DataGroup, which was List-oriented, has been copied to VirtualVDataGroup (and List adjusted).  Adjusted NonVirtualHDataGroup (used by TabBar) and commented out NonVirtualVDataGroup (not used).

- Added SelfItemRendererInitializer (+ SelfItemRenderer) to render UIComponent objects, such as VGroup and everything else.

- Moved ``public var dataGroup:DataGroup;`` from SkinnableComponent to ListBase.

- There are various existing layout bugs in components, and those are still reflected in DataGroup / SkinnableDataContainer, of course.

- While DataGroup is laying out subcontainers very well, SkinnableDataContainer is not.  For many uses, you can work around by using "DataGroup" instead of "SkinnableDataContainer" (the MXML, for example, stays the same, with the dataProvider and such).  But of course it would be nice to get SkinnableDataContainer working properly.  SkinnableContainer does not have the same issue (though it has other issues).  Not sure if List has the issue.
