### PR TITLE
Implement removeAllElements() for Spark SkinnableContainer.

### DIFF
--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/SkinnableContainer.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/SkinnableContainer.as
@@ -894,6 +894,12 @@ public class SkinnableContainer extends SkinnableContainerBase implements IConta
     {
         /* _contentModified = true;
         currentContentGroup.removeAllElements(); */
+
+        // Copied from mx.core.Container
+        while (numChildren > 0)
+        {
+            removeChildAt(0);
+        }
     } 
     
     /*


### PR DESCRIPTION
Can't use contentView to do this directly because the interface doesn't have a removeAllChildren().