### PR TITLE
Several suggestions for js\bin\mxmlc.bat

### DIFF
--- a/distribution/src/main/resources/js/bin/mxmlc.bat
+++ b/distribution/src/main/resources/js/bin/mxmlc.bat
@@ -22,6 +22,8 @@ rem mxmlc.bat script to launch compiler-mxmlc.jar in Windows Command Prompt.
 rem On OSX, Unix, or Cygwin, use the mxmlc shell script instead.
 rem
 
+setlocal
+
 if "x%ROYALE_COMPILER_HOME%"=="x"  (set "ROYALE_COMPILER_HOME=%~dp0..\..") else echo Using Royale Compiler codebase: %ROYALE_COMPILER_HOME%
 
 if "x%ROYALE_HOME%"=="x" (set "ROYALE_HOME=%~dp0..\..") else echo Using Royale SDK: %ROYALE_HOME%

--- a/js/bin/mxmlc.bat
+++ b/js/bin/mxmlc.bat
@@ -22,6 +22,8 @@ rem mxmlc.bat script to launch compiler-mxmlc.jar in Windows Command Prompt.
 rem On OSX, Unix, or Cygwin, use the mxmlc shell script instead.
 rem
 
+setlocal
+
 if "x%ROYALE_COMPILER_HOME%"=="x"  (set "ROYALE_COMPILER_HOME=%~dp0..\..") else echo Using Royale Compiler codebase: %ROYALE_COMPILER_HOME%
 
 if "x%ROYALE_HOME%"=="x" (set "ROYALE_HOME=%~dp0..\..") else echo Using Royale SDK: %ROYALE_HOME%

--- a/js/bin/mxmlc.bat
+++ b/js/bin/mxmlc.bat
@@ -28,4 +28,4 @@ if "x%ROYALE_COMPILER_HOME%"=="x"  (set "ROYALE_COMPILER_HOME=%~dp0..\..") else 
 
 if "x%ROYALE_HOME%"=="x" (set "ROYALE_HOME=%~dp0..\..") else echo Using Royale SDK: %ROYALE_HOME%
 
-@java -Dsun.io.useCanonCaches=false -Xms32m -Xmx512m -Droyalecompiler="%ROYALE_COMPILER_HOME%" -Droyalelib="%ROYALE_HOME%\frameworks" -jar "%ROYALE_COMPILER_HOME%\js\lib\mxmlc.jar"  -sdk-js-lib="%ROYALE_HOME%\frameworks\js\Royale\generated-sources" %*
+@java -Dsun.io.useCanonCaches=false -Xms128m -Xmx1024m -Droyalecompiler="%ROYALE_COMPILER_HOME%" -Droyalelib="%ROYALE_HOME%\frameworks" -jar "%ROYALE_COMPILER_HOME%\js\lib\mxmlc.jar"  -sdk-js-lib="%ROYALE_HOME%\frameworks\js\Royale\generated-sources" %*

--- a/js/bin/mxmlc.bat
+++ b/js/bin/mxmlc.bat
@@ -24,8 +24,8 @@ rem
 
 setlocal
 
-if "x%ROYALE_COMPILER_HOME%"=="x"  (set "ROYALE_COMPILER_HOME=%~dp0..\..") else echo Using Royale Compiler codebase: %ROYALE_COMPILER_HOME%
+if "x%ROYALE_COMPILER_HOME%"=="x"  (set "ROYALE_COMPILER_HOME=%~dp0..\..\js") else echo Using Royale Compiler codebase: %ROYALE_COMPILER_HOME%
 
 if "x%ROYALE_HOME%"=="x" (set "ROYALE_HOME=%~dp0..\..") else echo Using Royale SDK: %ROYALE_HOME%
 
-@java -Dsun.io.useCanonCaches=false -Xms128m -Xmx1024m -Droyalecompiler="%ROYALE_COMPILER_HOME%" -Droyalelib="%ROYALE_HOME%\frameworks" -jar "%ROYALE_COMPILER_HOME%\js\lib\mxmlc.jar"  -sdk-js-lib="%ROYALE_HOME%\frameworks\js\Royale\generated-sources" %*
+@java -Dsun.io.useCanonCaches=false -Xms128m -Xmx1024m -Droyalecompiler="%ROYALE_COMPILER_HOME%" -Droyalelib="%ROYALE_HOME%\frameworks" -jar "%ROYALE_COMPILER_HOME%\lib\mxmlc.jar"  -sdk-js-lib="%ROYALE_HOME%\frameworks\js\Royale\generated-sources" %*


### PR DESCRIPTION
o Added setlocal to mxmlc.bat files to prevent ROYALE_HOME, etc., from being set in the caller environment.

o Increased max memory for java to 1024 MB to prevent out-of-memory during release JS builds on modest app, and increased minimum memory to 128 MB to speed up compile by 5-10% on modest machine.

o **Adjusted ROYALE_COMPILER_HOME to be consistent with build.xml files (...\js).**  Note that the command-line define for "royalecompiler" seems to be ineffectual (so the change here should not be a problem for that);  there is no System.getProperty("royalecompiler") or such in the .java compiler code.
