### PR TITLE
Implement ObjectProxy.object as a workaround to do "for each" and "for" on ObjectProxy.

### DIFF
--- a/frameworks/projects/MXRoyale/src/main/royale/mx/utils/ObjectProxy.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/utils/ObjectProxy.as
@@ -266,16 +266,26 @@ public dynamic class ObjectProxy extends Proxy
 
     /**
      *  The object being proxied.
+     *
+     *  To enumerate keys:  for (key:String in objproxy.object)
+     *  To enumerate values:  for each (value in objproxy.object)
      *  
      *  @langversion 3.0
      *  @playerversion Flash 9
      *  @playerversion AIR 1.1
      *  @productversion Flex 3
      */
-//    object_proxy function get object():Object
-//    {
-//        return _item;
-//    }
+    COMPILE::SWF
+    object_proxy function get object():Object
+    {
+        return _item;
+    }
+
+    COMPILE::JS
+    public function get object():Object
+    {
+        return _item;
+    }
 
     //----------------------------------
     //  type


### PR DESCRIPTION
For Proxy or ObjectProxy, the compiler will generate a call to propertyNames() for both:

``for each (value in objproxy)``
and
``for (key:String in objproxy)``

For the second case, key is then equal to a number, instead of the key name.  (For the first case, traditionally you would modify getProperty() to take a number-string argument and return the appropriate value, and it's used automatically.)

As a workaround for both cases for ObjectProxy, the "object" (legacy) property is implemented, so you can do this instead:

``for each (value in objproxy.object)``
and
``for (key:String in objproxy.object)``

Not convenient enough, but it works.  This is only for the JS side;  it doesn't work on SWF (because object_proxy designation is protected), in Royale or Flex.

(Legacy "object" property is protected, not public, but JS side is already exposing several other protected functions--in this class and others--as public.)
