### PR TITLE
Implement propertyNames() in ObjectProxy for JS to allow enumerations using "for" and "for each"

### DIFF
--- a/frameworks/projects/Core/src/main/royale/org/apache/royale/utils/Proxy.as
+++ b/frameworks/projects/Core/src/main/royale/org/apache/royale/utils/Proxy.as
@@ -145,12 +145,13 @@ public dynamic class Proxy extends EventDispatcher
 		return delete valueMap[propName];
     }
 	
-	public function propertyNames():Array
+	public function propertyNames():Object
 	{
-		var names:Array = [];
-		for (var p:String in valueMap)
-			names.push(p);
-		return names;
+//		var names:Array = [];
+//		for (var p:String in valueMap)
+//			names.push(p);
+//		return names;
+		return valueMap;
 	}
 }
 

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/utils/ObjectProxy.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/utils/ObjectProxy.as
@@ -657,6 +657,16 @@ public dynamic class ObjectProxy extends Proxy
         }
     }
 
+    /*
+     *  To enumerate keys:  for (key:String in objproxy)
+     *  To enumerate values:  for each (value in objproxy)
+     */
+    COMPILE::JS
+    override public function propertyNames():Object
+    {
+        return _item;
+    }
+
     //--------------------------------------------------------------------------
     //
     //  object_proxy methods


### PR DESCRIPTION
And adjust Proxy version of propertyNames() for JS;  changed return type from Array to Object, to make it easier to override in ObjectProxy.

For Proxy or ObjectProxy, the compiler will generate a call to propertyNames() for both:

``for (key:String in objproxy)``
and
``for each (value in objproxy)``

(In the second case, it also generates a call to getProperty() to get the value based on the key returned in propertyNames().)

If propertyNames() returns Object (instead of Array), then JS can handle the rest.  (At least for non-complex properties.)
