### PR TITLE
Change Spark Scroller to allow viewport to be set after Scroller is added to its parent.

### DIFF
--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/Scroller.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/Scroller.as
@@ -1116,6 +1116,15 @@ public class Scroller extends SkinnableComponent
      */
     private function installViewport():void
     {
+        if (!viewport) return;
+        
+    		// moved from addedToParent()
+		var vp:UIComponent = _viewport as UIComponent;
+		if (vp.isWidthSizedToContent())
+        		vp.setWidth(width);
+		if (vp.isHeightSizedToContent())
+        		vp.setHeight(height);
+
         /*  SWF?
         if (skin && viewport)
         {*/
@@ -3895,11 +3904,6 @@ public class Scroller extends SkinnableComponent
     override public function addedToParent():void
     {
         super.addedToParent();
-		var vp:UIComponent = _viewport as UIComponent;
-		if (vp.isWidthSizedToContent())
-        		vp.setWidth(width);
-		if (vp.isHeightSizedToContent())
-        		vp.setHeight(height);
         installViewport();
     }
     


### PR DESCRIPTION
To match what was possible under Flex.

Just moved some code from addedToParent() into installViewport() [which was already being called by addedToParent()], and added a null reference check.
