### PR TITLE
Fix 2 AMF issues in JS build:

### DIFF
--- a/frameworks/projects/MXRoyale/src/main/royale/mx/net/NetConnection.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/net/NetConnection.as
@@ -150,7 +150,8 @@ public class NetConnection extends EventDispatcher
         var ncResponder:org.apache.royale.net.Responder = 
                         new org.apache.royale.net.Responder(responder.resultFunction,
                                                               responder.faultFunction);
-        nc.call(null, ncResponder, message);
+        // Jim P: pass the AMF target URI in here 
+        nc.call(thisObject as String, ncResponder, message);
     }
 }
 

--- a/frameworks/projects/Network/src/main/royale/org/apache/royale/net/remoting/amf/AMFNetConnection.as
+++ b/frameworks/projects/Network/src/main/royale/org/apache/royale/net/remoting/amf/AMFNetConnection.as
@@ -287,7 +287,11 @@ public class AMFNetConnection
      *  @productversion BlazeDS 4
      *  @productversion LCDS 3
      */
-    public function call(command:String, responder:Responder, ... params):void
+    /* JimP: params should match what is sent into NetConnection.call, which is currently an IMessage.
+       If a 'rest' variable is used then only the first member of a passed array arrives. Fixed by
+       changing to an Object.
+    */
+    public function call(command:String, responder:Responder, params:Object):void
     {
         COMPILE::SWF
         {
@@ -301,6 +305,8 @@ public class AMFNetConnection
             requestQueue.push(
                     {
                         url: url,
+                        /* JimP: this is the AMF URI */
+                        target: command,
                         responder: responder,
                         args: params
                     }
@@ -328,6 +334,8 @@ public class AMFNetConnection
             var actionMessage:ActionMessage = new ActionMessage();
             var messageBody:MessageBody = new MessageBody();
             sequence++;
+            /* insert the AMF URI into the body, otherwise it's always 'null' */
+            messageBody.targetURI = call.item.target;
             messageBody.responseURI = "/" + sequence.toString();
             messageBody.data = args;
             actionMessage.bodies = [ messageBody ];


### PR DESCRIPTION
This fix attempts to fix two problems I found when when making calls to our AMF service:

1) pass in the AMF URI, as currently it's always NULL, and set it in the messageBody
2) fix the 'params' parameter in AMFNetConnection.call, as otherwise it's not possible to send in an array of optional parameters

My main concern in committing this back to the repo is that it changes the signature of `AMFNetConnection.call()`. This is only one solution to the problem. It may be possible to fix the issue by using `.apply()` on the call to that function from `NetConnection.call()` - I will investigate it but I think it would still require some contortions in `AMFNetConnection.call()` to get the desired effect.

The other thing to consider is that `NetConnection.call()` has a different signature in royale compared to flex. I assume this was done for a reason so I didn't change that ... but it matches `AMFNetConnection.call()`. If not then reverting to the flex signature would make existing AMF services easier to port.

Anyway, by all means have a look and let me know your thoughts.