### PR TITLE
Remove @royaleignorecoercion from several UIComponent methods

### DIFF
--- a/frameworks/projects/MXRoyale/src/main/royale/mx/core/UIComponent.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/core/UIComponent.as
@@ -1424,6 +1424,7 @@ public class UIComponent extends UIBase
      *  @playerversion Flash 9
      *  @playerversion AIR 1.1
      *  @productversion Flex 3
+     *  @royaleemitcoercion mx.core.IUIComponent
      */
     public function get owner():IUIComponent
     {
@@ -3591,15 +3592,16 @@ COMPILE::JS
     { override }
     public function addChild(child:IUIComponent):IUIComponent
     {
-        return addElement(child) as IUIComponent;
+        addElement(child);
+        return child;
     }
     
     
     public function $uibase_addChild(child:IUIComponent):IUIComponent
     {
         // this should avoid calls to addingChild/childAdded
-        var ret:IUIComponent = super.addElement(child) as IUIComponent;
-        return ret;
+        super.addElement(child);
+        return child;
     }
 
     /**
@@ -3608,22 +3610,20 @@ COMPILE::JS
     [SWFOverride(params="flash.display.DisplayObject,int", altparams="mx.core.UIComponent,int", returns="flash.display.DisplayObject"))]
     COMPILE::SWF 
     { override }
-    public function addChildAt(child:IUIComponent,
-                                        index:int):IUIComponent
+    public function addChildAt(child:IUIComponent, index:int):IUIComponent
     {
-        return addElementAt(child, index) as IUIComponent;
+        addElementAt(child, index);
+        return child;
     }
     
-    public function $uibase_addChildAt(child:IUIComponent,
-                               index:int):IUIComponent
+    public function $uibase_addChildAt(child:IUIComponent, index:int):IUIComponent
     {
-        var ret:IUIComponent;
         // this should avoid calls to addingChild/childAdded
         if (index >= super.numElements)
-            ret = super.addElement(child) as IUIComponent;
+            super.addElement(child);
         else
-            ret = super.addElementAt(child, index) as IUIComponent;
-        return ret;
+            super.addElementAt(child, index);
+        return child;
     }
 
     /**
@@ -3634,14 +3634,15 @@ COMPILE::JS
     { override }
     public function removeChild(child:IUIComponent):IUIComponent
     {
-        return removeElement(child) as IUIComponent;
+        removeElement(child)
+        return child;
     }
     
     public function $uibase_removeChild(child:IUIComponent):IUIComponent
     {
         // this should probably call the removingChild/childRemoved
-        var ret:IUIComponent = super.removeElement(child) as IUIComponent;
-        return ret;
+        super.removeElement(child);
+        return child;
     }
     
     COMPILE::JS
@@ -3649,26 +3650,35 @@ COMPILE::JS
 	{
 	
 	}
+
     /**
      *  @private
+     *  @royaleemitcoercion mx.core.IUIComponent
      */
     [SWFOverride(returns="flash.display.DisplayObject"))]
     COMPILE::SWF 
     { override }
     public function removeChildAt(index:int):IUIComponent
     {
+        var child:IUIComponent = getElementAt(index) as IUIComponent;
         // this should probably call the removingChild/childRemoved
-        return removeElement(getElementAt(index)) as IUIComponent;
+        removeElement(child);
+        return child;
     }
     
+    /**
+     *  @royaleemitcoercion mx.core.IUIComponent
+     */
     public function $uibase_removeChildAt(index:int):IUIComponent
     {
-        var ret:IUIComponent = super.removeElement(getElementAt(index)) as IUIComponent;
-        return ret;
+        var child:IUIComponent = getElementAt(index) as IUIComponent;
+        super.removeElement(child);
+        return child;
     }
 
     /**
      *  @private
+     *  @royaleemitcoercion mx.core.IUIComponent
      */
     [SWFOverride(returns="flash.display.DisplayObject"))]
     COMPILE::SWF 

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/core/UIComponent.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/core/UIComponent.as
@@ -97,6 +97,7 @@ import org.apache.royale.geom.Rectangle;
 import org.apache.royale.html.beads.DisableBead;
 import org.apache.royale.html.beads.DisabledAlphaBead;
 import org.apache.royale.html.supportClasses.ContainerContentArea;
+import org.apache.royale.reflection.getQualifiedClassName;
 import org.apache.royale.utils.PointUtils;
 import org.apache.royale.utils.CSSUtils;
 import org.apache.royale.utils.loadBeadFromValuesManager;
@@ -2404,7 +2405,7 @@ COMPILE::JS
                         if (child) // child is null for TextNodes
                             mw = Math.max(mw, child.getExplicitOrMeasuredWidth());
                         else
-                            trace("Child class not IUIComponent: " + getElementAt(i)["ROYALE_CLASS_INFO"].names[0].qName);
+                            trace("Child class not IUIComponent: " + getQualifiedClassName(getElementAt(i)));
                     }
                 }
                 if (oldWidth.length)
@@ -2480,7 +2481,7 @@ COMPILE::JS
                         if (child)
                             mh = Math.max(mh, child.getExplicitOrMeasuredHeight());
                         else
-                            trace("Child class not IUIComponent: " + getElementAt(i)["ROYALE_CLASS_INFO"].names[0].qName);
+                            trace("Child class not IUIComponent: " + getQualifiedClassName(getElementAt(i)));
                     }
                 }
                 if (oldHeight.length)

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/core/UIComponent.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/core/UIComponent.as
@@ -988,7 +988,6 @@ public class UIComponent extends UIBase
      *  @playerversion Flash 9
      *  @playerversion AIR 1.1
      *  @productversion Flex 3
-     *  @royaleignorecoercion mx.core.IUIComponent
      */
     COMPILE::JS
     public function get name():String
@@ -1425,7 +1424,6 @@ public class UIComponent extends UIBase
      *  @playerversion Flash 9
      *  @playerversion AIR 1.1
      *  @productversion Flex 3
-     *  @royaleignorecoercion mx.core.IUIComponent
      */
     public function get owner():IUIComponent
     {
@@ -2404,6 +2402,8 @@ COMPILE::JS
                         var child:IUIComponent = getChildAt(i);
                         if (child) // child is null for TextNodes
                             mw = Math.max(mw, child.getExplicitOrMeasuredWidth());
+                        else
+                            trace("Child class not IUIComponent: " + getElementAt(i)["ROYALE_CLASS_INFO"].names[0].qName);
                     }
                 }
                 if (oldWidth.length)
@@ -2478,6 +2478,8 @@ COMPILE::JS
                         var child:IUIComponent = getChildAt(i);
                         if (child)
                             mh = Math.max(mh, child.getExplicitOrMeasuredHeight());
+                        else
+                            trace("Child class not IUIComponent: " + getElementAt(i)["ROYALE_CLASS_INFO"].names[0].qName);
                     }
                 }
                 if (oldHeight.length)
@@ -3583,7 +3585,6 @@ COMPILE::JS
 
     /**
      *  @private
-     *  @royaleignorecoercion mx.core.IUIComponent
      */
     [SWFOverride(params="flash.display.DisplayObject", altparams="mx.core.UIComponent", returns="flash.display.DisplayObject"))]
     COMPILE::SWF 
@@ -3603,7 +3604,6 @@ COMPILE::JS
 
     /**
      *  @private
-     *  @royaleignorecoercion mx.core.IUIComponent
      */
     [SWFOverride(params="flash.display.DisplayObject,int", altparams="mx.core.UIComponent,int", returns="flash.display.DisplayObject"))]
     COMPILE::SWF 
@@ -3628,7 +3628,6 @@ COMPILE::JS
 
     /**
      *  @private
-     *  @royaleignorecoercion mx.core.IUIComponent
      */
     [SWFOverride(params="flash.display.DisplayObject", altparams="mx.core.UIComponent", returns="flash.display.DisplayObject"))]
     COMPILE::SWF 
@@ -3652,7 +3651,6 @@ COMPILE::JS
 	}
     /**
      *  @private
-     *  @royaleignorecoercion mx.core.IUIComponent
      */
     [SWFOverride(returns="flash.display.DisplayObject"))]
     COMPILE::SWF 
@@ -3671,7 +3669,6 @@ COMPILE::JS
 
     /**
      *  @private
-     *  @royaleignorecoercion mx.core.IUIComponent
      */
     [SWFOverride(returns="flash.display.DisplayObject"))]
     COMPILE::SWF 
@@ -6280,8 +6277,6 @@ COMPILE::JS
      *  @playerversion Flash 10.2
      *  @playerversion AIR 2.6
      *  @productversion Royale 0.0
-     *  @royaleignorecoercion org.apache.royale.core.WrappedHTMLElement
-     *  @royaleignorecoercion org.apache.royale.events.IEventDispatcher
      */
     override public function get topMostEventDispatcher():IEventDispatcher
     {


### PR DESCRIPTION
Remove @royaleignorecoercion from several UIComponent methods (which affected "return" statements), because they allowed non-IUIComponent objects to be returned (in JS) when the method declaration promised an IUIComponent object.  Also add code to easily detect non-IUIComponent child objects during get measuredWidth() / measuredHeight() in JS.

(I was originally going to submit with a temporary workaround by doing a typeof(child.getExplicitOrMeasuredHeight) != "function" in measuredHeight(), for example, to detect non-IUIComponent objects.  But PR #1026 was merged, so I changed this to the real fixes.)

Several UIComponent methods, like getChildAt(), would return non-null values that did not actually implement IUIComponent, even though the return value for the methods promised that.  There are multiple ways to handle that, but at the end of the day, it's really really bad for a typed language to allow this (without a really good reason).  The only reason was performance, but that should be much better now.

Several people have reported (and several maintainers have correctly diagnosed) an error similar to the following:

```
Uncaught TypeError: child.getExplicitOrMeasuredHeight is not a function
    get__measuredHeight .../mx/core/UIComponent.js:3091
    getExplicitOrMeasuredHeight .../mx/core/UIComponent.js:1432
    getPreferredUBoundsHeight .../mx/core/LayoutElementUIComponentUtils.js:72
    getPreferredBoundsHeight .../mx/core/LayoutElementUIComponentUtils.js:166
    getPreferredBoundsHeight .../mx/core/UIComponent.js:1950
    spark_layouts_VerticalLayout_getElementHeight .../spark/layouts/VerticalLayout.js:556
```

The error is caused by UIComponent.getChildAt() returning an object that does not actually implement IUIComponent.  This typically happens because an emulation class derived from a non-MX / non-Spark class doesn't implement IUIComponent.

Essentially the same issue was reported in #789 and #983.

With the changes in this PR, the following are some of the classes--identified by the new trace() code--that don't implement IUIComponent:

```
Child class not IUIComponent: mx.controls.advancedDataGridClasses.AdvancedDataGridButtonBar
Child class not IUIComponent: mx.controls.advancedDataGridClasses.AdvancedDataGridListArea
```

And sure enough, they are thin wrappers on non-MX classes, with no implementation of IUIComponent.

[Aside:  I don't know the best way to implement getExplicitOrMeasuredWidth() / getExplicitOrMeasuredHeight() for these classes, off-hand.  (Explicit width/height is there, but don't know the measured values.)  I don't know how much work is needed for the other IUIComponent pieces.]
