### PR TITLE
MX ADG: Fix memory leak due to grid item renderer leak on dataProviderChange events

### DIFF
--- a/frameworks/projects/MXRoyale/src/main/royale/mx/containers/beads/AdvancedDataGridListVirtualListView.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/containers/beads/AdvancedDataGridListVirtualListView.as
@@ -25,7 +25,9 @@ COMPILE::SWF
 {
     import org.apache.royale.core.IStrand;
 }
+import org.apache.royale.core.IChild;
 import org.apache.royale.core.IItemRenderer;
+import org.apache.royale.core.IParent;
 import org.apache.royale.core.IRollOverModel;
 import org.apache.royale.core.ISelectableItemRenderer;
 import org.apache.royale.core.ISelectionModel;
@@ -107,6 +109,23 @@ public class AdvancedDataGridListVirtualListView extends VirtualListView
         }
     }
 
+    /**
+     * @copy org.apache.royale.core.IItemRendererOwnerView#removeAllItemRenderers()
+     * @private
+     *
+     *  @langversion 3.0
+     *  @playerversion Flash 10.2
+     *  @playerversion AIR 2.6
+     *  @productversion Royale 0.9.8
+     *  @royaleignorecoercion org.apache.royale.core.IParent
+     */
+    override public function removeAllItemRenderers():void
+    {
+        while ((contentView as IParent).numElements > 0) {
+            var child:IChild = (contentView as IParent).getElementAt(0);
+            (contentView as IParent).removeElement(child);
+        }
+    }
 }
 }
 

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/controls/advancedDataGridClasses/DataItemRendererFactoryForICollectionViewAdvancedDataGridData.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/controls/advancedDataGridClasses/DataItemRendererFactoryForICollectionViewAdvancedDataGridData.as
@@ -107,8 +107,9 @@ package mx.controls.advancedDataGridClasses
             //dped.addEventListener(CollectionEvent.ITEM_REMOVED, itemRemovedHandler);
             //dped.addEventListener(CollectionEvent.ITEM_UPDATED, itemUpdatedHandler);
             
-            //dataGroup.removeAllItemRenderers();
-                        
+            var view:IListView = (_strand as IStrandWithModelView).view as IListView;
+            var dataGroup:IItemRendererOwnerView = view.dataGroup;
+            dataGroup.removeAllItemRenderers();                        
             rendererMap = {};
             IEventDispatcher(_strand).dispatchEvent(new Event("itemsCreated"));
             IEventDispatcher(_strand).dispatchEvent(new Event("layoutNeeded"));


### PR DESCRIPTION
Caused by March 2020 change to clear out rendererMap (which was a good change).

Can be a massive memory leak, depending on the frequency of dataProviderChange events and how much data is involved.  Had an app that leaked 3 GB of memory per day.

Had to adjust removeAllItemRenderers(), too, because ADG doesn't do the whole royale_wrapper thing.