### PR TITLE
Add method finalizeThis() to IViewCursor, and fix memory leak in MX ADG due to event listener leak

### DIFF
--- a/frameworks/projects/MXRoyale/src/main/royale/mx/collections/HierarchicalCollectionViewCursor.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/collections/HierarchicalCollectionViewCursor.as
@@ -93,6 +93,21 @@ public class HierarchicalCollectionViewCursor extends EventDispatcher
         //check to see if the model has more than one top level items
         more = model.length > 1;
     }
+
+    /**
+     *  Finalizes the cursor, to clean up resources.
+     *  Required because weak references are not available in JS.
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Royale 0.9.8
+     */
+    public function finalizeThis():void
+    {
+        if (modelCursor) modelCursor.finalizeThis();
+        if (collection) collection.removeEventListener(CollectionEvent.COLLECTION_CHANGE, collectionChangeHandler);
+    }
     
     //--------------------------------------------------------------------------
     //

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/collections/IViewCursor.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/collections/IViewCursor.as
@@ -167,6 +167,17 @@ public interface IViewCursor extends IEventDispatcher
     //--------------------------------------------------------------------------
 
     /**
+     *  Finalizes the cursor, to clean up resources.
+     *  Required because weak references are not available in JS.
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Royale 0.9.8
+     */
+    function finalizeThis():void;
+
+    /**
      *  Finds an item with the specified properties within the collection
      *  and positions the cursor to that item.
      *  If the item cannot be found, the cursor location does not change.

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/collections/LeafNodeCursor.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/collections/LeafNodeCursor.as
@@ -84,6 +84,20 @@ public class LeafNodeCursor extends EventDispatcher
 			
     }
 
+    /**
+     *  Finalizes the cursor, to clean up resources.
+     *  Required because weak references are not available in JS.
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Royale 0.9.8
+     */
+    public function finalizeThis():void
+    {
+        if (modelCursor) modelCursor.finalizeThis();
+    }
+
     //--------------------------------------------------------------------------
     //
     //  Variables

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/collections/ListCollectionView.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/collections/ListCollectionView.as
@@ -2069,6 +2069,20 @@ class ListCollectionViewCursor extends EventDispatcher implements IViewCursor
             */
         }
     }
+    
+    /**
+     *  Finalizes the cursor, to clean up resources.
+     *  Required because weak references are not available in JS.
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Royale 0.9.8
+     */
+    public function finalizeThis():void
+    {
+        if (_view) _view.removeEventListener(CollectionEvent.COLLECTION_CHANGE, collectionEventHandler);
+    }
 
     //--------------------------------------------------------------------------
     //

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/controls/advancedDataGridClasses/DataItemRendererFactoryForICollectionViewAdvancedDataGridData.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/controls/advancedDataGridClasses/DataItemRendererFactoryForICollectionViewAdvancedDataGridData.as
@@ -97,7 +97,8 @@ package mx.controls.advancedDataGridClasses
             var dp:ICollectionView = dataProviderModel.dataProvider as ICollectionView;
             if (!dp)
                 return;
-            
+
+            if (cursor) cursor.finalizeThis();
             cursor = dp.createCursor();
             currentIndex = (dp.length > 0) ? 0 : -1;
             

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/controls/treeClasses/HierarchicalViewCursor.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/controls/treeClasses/HierarchicalViewCursor.as
@@ -86,6 +86,21 @@ public class HierarchicalViewCursor extends EventDispatcher
 		more = model.length > 1;
     }
 
+    /**
+     *  Finalizes the cursor, to clean up resources.
+     *  Required because weak references are not available in JS.
+     *  
+     *  @langversion 3.0
+     *  @playerversion Flash 9
+     *  @playerversion AIR 1.1
+     *  @productversion Royale 0.9.8
+     */
+    public function finalizeThis():void
+    {
+        if (modelCursor) modelCursor.finalizeThis();
+        if (collection) collection.removeEventListener(CollectionEvent.COLLECTION_CHANGE, collectionChangeHandler);
+    }
+
     //--------------------------------------------------------------------------
     //
     //  Variables


### PR DESCRIPTION
Add method finalizeThis() to IViewCursor, and fix memory leak in MX ADG due to event listener leak, due to lack of weak references in JS.

In Flex, these cursors had addEventListener() with the 5th arg = true for a weak reference (because, in MX ADG, the cursor listens to its view, which then gets a reference to the cursor, and the view is longer-lived).  In JS, the reference is no longer weak, and the event listener references (to the cursors) are being kept around as the item renderers are removed and recreated on dataProviderChange events.  This adds up to a significant memory leak over time and excessive listeners.

I don't know what the general strategy is for calling removeEventListener() on such items, so I added finalizeThis() to the interface (MX IViewCursor) and made sure, at least for MX ADG, that it is called during destruction of each cursor.

(There are other event listener leaks going on in MX ADG.  This was the biggest one.)