### PR TITLE
MX ADG: Fix scroll handler (under async scroll events) and optimize current implementation of ADG

### DIFF
--- a/frameworks/projects/Basic/src/main/royale/org/apache/royale/core/UIBase.as
+++ b/frameworks/projects/Basic/src/main/royale/org/apache/royale/core/UIBase.as
@@ -723,13 +723,14 @@ package org.apache.royale.core
         {
             if(!isNaN(_x))
                 return _x
-            var strpixels:String = positioner.style.left as String;
+            var pos:WrappedHTMLElement = positioner;
+            var strpixels:String = pos.style.left as String;
             var pixels:Number = parseFloat(strpixels);
             if (isNaN(pixels))
             {
-                pixels = positioner.offsetLeft;
-                if (positioner.parentNode != positioner.offsetParent)
-                    pixels -= (positioner.parentNode as HTMLElement).offsetLeft;
+                pixels = pos.offsetLeft;
+                if (pos.parentNode != pos.offsetParent)
+                    pixels -= (pos.parentNode as HTMLElement).offsetLeft;
             }
             return pixels;
         }
@@ -751,10 +752,11 @@ package org.apache.royale.core
 			}
 			COMPILE::JS
 			{
-				//positioner.style.position = 'absolute';
-                if (positioner.parentNode != positioner.offsetParent)
-                    value += (positioner.parentNode as HTMLElement).offsetLeft;
-                positioner.style.left = value.toString() + 'px';
+                var pos:WrappedHTMLElement = positioner;
+				//pos.style.position = 'absolute';
+                if (pos.parentNode != pos.offsetParent)
+                    value += (pos.parentNode as HTMLElement).offsetLeft;
+                pos.style.left = value.toString() + 'px';
 			}
         }
         
@@ -792,13 +794,14 @@ package org.apache.royale.core
         {
             if(!isNaN(_y))
                 return _y
-            var strpixels:String = positioner.style.top as String;
+            var pos:WrappedHTMLElement = positioner;
+            var strpixels:String = pos.style.top as String;
             var pixels:Number = parseFloat(strpixels);
             if (isNaN(pixels))
             {
-                pixels = positioner.offsetTop;
-                if (positioner.parentNode != positioner.offsetParent)
-                    pixels -= (positioner.parentNode as HTMLElement).offsetTop;
+                pixels = pos.offsetTop;
+                if (pos.parentNode != pos.offsetParent)
+                    pixels -= (pos.parentNode as HTMLElement).offsetTop;
             }
             return pixels;
         }
@@ -820,10 +823,11 @@ package org.apache.royale.core
 			}
 			COMPILE::JS
 			{
-				//positioner.style.position = 'absolute';
-                if (positioner.parentNode != positioner.offsetParent)
-                    value += (positioner.parentNode as HTMLElement).offsetTop;
-                positioner.style.top = value.toString() + 'px';
+                var pos:WrappedHTMLElement = positioner;
+				//pos.style.position = 'absolute';
+                if (pos.parentNode != pos.offsetParent)
+                    value += (pos.parentNode as HTMLElement).offsetTop;
+                pos.style.top = value.toString() + 'px';
 			}
         }
         

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/containers/beads/AdvancedDataGridHeaderLayout.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/containers/beads/AdvancedDataGridHeaderLayout.as
@@ -148,26 +148,25 @@ public class AdvancedDataGridHeaderLayout extends LayoutBase
             if (ilc == null || !ilc.visible) continue;
             if (!(ilc is AdvancedDataGridHeaderRenderer)) continue;
             
-            COMPILE::SWF {
-                if (buttonWidths) {
-                    var widthValue:* = buttonWidths[i];
-                    
-                    if (widthValue != null) ilc.width = Number(widthValue);
-                    ilc.x = xx;
-                    xx += ilc.width;
-                }
-            }
-                
             COMPILE::JS {
                 if (!host.isHeightSizedToContent())
                     ilc.height = contentView.height;
-                if (buttonWidths) {
-                    var widthValue:* = buttonWidths[i];
-                    if (widthValue != null) ilc.width = Number(widthValue);
-                    ilc.x = xx;
-                    xx += ilc.width;
-                }                
             }
+
+            if (buttonWidths) {
+                var widthValue:* = buttonWidths[i];
+                if (widthValue != null) 
+                {
+                    ilc.width = Number(widthValue);
+
+                    // call updateDisplayList()
+                    var adghr:AdvancedDataGridHeaderRenderer = ilc as AdvancedDataGridHeaderRenderer;
+                    adghr.invalidateDisplayList();
+                    adghr.validateDisplayList();
+                }
+                ilc.x = xx;
+                xx += ilc.width;
+            }                
         }
         
         return true;

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/controls/advancedDataGridClasses/AdvancedDataGridHeaderRenderer.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/controls/advancedDataGridClasses/AdvancedDataGridHeaderRenderer.as
@@ -331,6 +331,7 @@ public class AdvancedDataGridHeaderRenderer extends UIComponent implements IData
                 col.dataField, 
                 col.colNum, "", col.owner);
         listData = ld;
+        isLabelTextChanged = true;
         
         invalidateProperties();
         commitProperties();
@@ -474,6 +475,7 @@ public class AdvancedDataGridHeaderRenderer extends UIComponent implements IData
      */
     override protected function commitProperties():void
     {
+        //trace("AdvancedDataGridHeaderRenderer.commitProperties() called");
         super.commitProperties();
 
         if (!initialized)
@@ -588,8 +590,9 @@ public class AdvancedDataGridHeaderRenderer extends UIComponent implements IData
     /**
      *  @private
      */
-    override protected function measure():void
+    /* override protected function measure():void
     {
+        trace("AdvancedDataGridHeaderRenderer.measure() called");
         super.measure();
 
         // Cache padding values
@@ -653,7 +656,16 @@ public class AdvancedDataGridHeaderRenderer extends UIComponent implements IData
         // Set required width and height
         measuredMinWidth  = measuredWidth  = w;
         measuredMinHeight = measuredHeight = h;
-    } 
+    } */
+    
+    override public function validateDisplayList():void
+    {
+        if (invalidateDisplayListFlag) updateDisplayList(width, height);
+    }
+
+    private var styleCache:Object;
+    private var isLabelTextChanged:Boolean = true;
+    private var lineMetricsWidth:Number;
     
     /**
      *  @private
@@ -665,12 +677,28 @@ public class AdvancedDataGridHeaderRenderer extends UIComponent implements IData
 
         if (unscaledWidth == 0)
             return;
+            
+        if (!styleCache)
+        {
+            // until AdvancedDataGridHeaderRenderer is refactored to be more Royalely,
+            // and/or until getStyle() is cheaper, try to avoid getStyle() calls,
+            // at the expense of some flexiblity
+            //
+            styleCache = new Object();
+            styleCache["paddingLeft"] = getStyle("paddingLeft");
+            styleCache["paddingRight"] = getStyle("paddingRight");
+            styleCache["paddingTop"] = getStyle("paddingTop");
+            styleCache["paddingBottom"] = getStyle("paddingBottom");
+            styleCache["horizontalGap"] = getStyle("horizontalGap");
+            styleCache["horizontalAlign"] = getStyle("horizontalAlign");
+            styleCache["verticalAlign"] = getStyle("verticalAlign");
+        }
 
         // Cache padding values
-        var paddingLeft:int   = getStyle("paddingLeft");
-        var paddingRight:int  = getStyle("paddingRight");
-        var paddingTop:int    = getStyle("paddingTop");
-        var paddingBottom:int = getStyle("paddingBottom");
+        var paddingLeft:int   = styleCache["paddingLeft"];
+        var paddingRight:int  = styleCache["paddingRight"];
+        var paddingTop:int    = styleCache["paddingTop"];
+        var paddingBottom:int = styleCache["paddingBottom"];
 
         // Size of sortItemRenderer
         var sortItemRendererWidth:Number  = sortItemRendererInstance ?
@@ -686,13 +714,18 @@ public class AdvancedDataGridHeaderRenderer extends UIComponent implements IData
             sortItemRendererHeight = 0;
         }
 
-        var horizontalGap:Number = getStyle("horizontalGap");
+        var horizontalGap:Number = styleCache["horizontalGap"];
         if (sortItemRendererWidth == 0)
             horizontalGap = 0;
 
         // Adjust to given width
-        var lineMetrics:TextLineMetrics = measureText(usingHTML ? label.htmlText: label.text);
-        var labelWidth:Number  = lineMetrics.width + UITextField.TEXT_WIDTH_PADDING;
+        if (isLabelTextChanged)
+        {
+            var lineMetrics:TextLineMetrics = measureText(usingHTML ? label.htmlText: label.text);
+            lineMetricsWidth = lineMetrics.width;
+            isLabelTextChanged = false;
+        }
+        var labelWidth:Number  = lineMetricsWidth + UITextField.TEXT_WIDTH_PADDING;
         var maxLabelWidth:int = unscaledWidth - sortItemRendererWidth
                                 - horizontalGap - paddingLeft - paddingRight;
         if (maxLabelWidth < 0)
@@ -725,7 +758,7 @@ public class AdvancedDataGridHeaderRenderer extends UIComponent implements IData
 
         // Calculate position of label, by default center it
         var labelX:Number;
-        var horizontalAlign:String = getStyle("horizontalAlign");
+        var horizontalAlign:String = styleCache["horizontalAlign"];
         if (horizontalAlign == "left")
         {
             labelX = paddingLeft;
@@ -748,7 +781,7 @@ public class AdvancedDataGridHeaderRenderer extends UIComponent implements IData
             labelAreaHeight /= 2;
         
         var labelY:Number;
-        var verticalAlign:String = getStyle("verticalAlign");
+        var verticalAlign:String = styleCache["verticalAlign"];
         if (verticalAlign == "top")
         {
             labelY = paddingTop;
@@ -785,7 +818,7 @@ public class AdvancedDataGridHeaderRenderer extends UIComponent implements IData
         }
 
         // Draw the separator
-        graphics.clear();
+//        graphics.clear();
         if (sortItemRendererInstance && !grid.sortExpertMode
                 &&  !(_data is AdvancedDataGridColumnGroup))
         {
@@ -805,31 +838,31 @@ public class AdvancedDataGridHeaderRenderer extends UIComponent implements IData
         }
 
         // Set text color
-        var labelColor:Number;
-
-        if (data && parent)
-        {
-            if (!enabled)
-                labelColor = getStyle("disabledColor");
-            // else if (grid.isItemHighlighted(listData.uid))
-            //     labelColor = getStyle("textRollOverColor");
-            //else if (grid.isItemSelected(listData.uid))
-            //    labelColor = getStyle("textSelectedColor");
-            else
-                labelColor = getStyle("color");
-
-           label.setColor(labelColor);
-        }
+//        var labelColor:Number;
+//
+//        if (data && parent)
+//        {
+//            if (!enabled)
+//                labelColor = getStyle("disabledColor");
+//            // else if (grid.isItemHighlighted(listData.uid))
+//            //     labelColor = getStyle("textRollOverColor");
+//            //else if (grid.isItemSelected(listData.uid))
+//            //    labelColor = getStyle("textSelectedColor");
+//            else
+//                labelColor = getStyle("color");
+//
+//           label.setColor(labelColor);
+//        }
 
         // Set background size, position, color
-        if (background)
-        {
-            background.graphics.clear();
-            background.graphics.beginFill(0xFFFFFF, 0.0); // transparent
-            background.graphics.drawRect(0, 0, unscaledWidth, unscaledHeight);
-            background.graphics.endFill();
-            setChildIndex( IUIComponent(background), 0 );
-        }
+//        if (background)
+//        {
+//            background.graphics.clear();
+//            background.graphics.beginFill(0xFFFFFF, 0.0); // transparent
+//            background.graphics.drawRect(0, 0, unscaledWidth, unscaledHeight);
+//            background.graphics.endFill();
+//            setChildIndex( IUIComponent(background), 0 );
+//        }
         if (childHeaders)
         {
             var adgcg:AdvancedDataGridColumnGroup = data as AdvancedDataGridColumnGroup;
@@ -952,11 +985,11 @@ public class AdvancedDataGridHeaderRenderer extends UIComponent implements IData
         return label;
     } 
 
-    override public function setWidth(value:Number, noEvent:Boolean = false):void
-    {
-        super.setWidth(value, noEvent);
-        updateDisplayList(width, height);
-    }
+//    override public function setWidth(value:Number, noEvent:Boolean = false):void
+//    {
+//        super.setWidth(value, noEvent);
+//        updateDisplayList(width, height);
+//    }
 
     override public function get systemManager():ISystemManager
     {

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/controls/beads/layouts/AdvancedDataGridLayout.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/controls/beads/layouts/AdvancedDataGridLayout.as
@@ -58,12 +58,6 @@ package mx.controls.beads.layouts
 		{
         }
         
-       /* override protected function scrollHandler(e:Event):void
-        {
-            layout();
-        }*/
-
-
         override protected function setHeaderWidths(columnWidths:Array):void
         {
             var header:IUIBase = (uiHost.view as IDataGridView).header;


### PR DESCRIPTION
Fixed scroll handler (under async scroll events) and optimize current implementation of MX ADG, especially with regard to header renderers.

The "deferred" logic for the scroll handler in ADG (in MX DataGridLayout) wasn't quite right, and under async scroll events in more recent browsers, it fired too often.  More room for improvement, but should be better.

**Even with the following ADG optimizations, scrolling is still not as smooth as it should be.**  In fact, with the way the scroll event is hooked, it really doesn't tolerate much rendering time.  Now, in release mode, it may be barely acceptable for grids with more than a few columns and rows.

Removed things and cached things in ADG header renderers to optimize.  They need more refactoring to be more Royale-like, but this is some progress (and is a lot faster).  Note that to work around very slow getStyle(), some header styles are not as dynamic.

Some simple optimization (fetch positioner into variable) in a few UIBase methods (x, y, setX, setY) to reduce the number of function calls (even though function calls are cheap in JS, these are high-impact methods).

Added override of validateDisplayList() to AdvancedDataGridHeaderRenderer so that AdvancedDataGridHeaderLayout had a way to call AdvancedDataGridHeaderRenderer.updateDisplayList() [which is protected].  Previously, it was being called through setWidth(), but that's the wrong place and even more expensive.

Moved the scrollTop workaround (for whatever Chrome bug) to after the loop, for DOM performance.

Did some naughty style caching (through the owner grid) in AdvancedDataGridSelectableItemRendererBead so that the first load of cached styles can be shared among the beads over all the renderers, for performance.  Hopefully that can be rewritten with faster stuff in a normal way later.  [Did it this way because I can't find a good place to push the styles from the owner grid to each bead as it gets added.]