### PR TITLE
Spark TabBarController: Handle dataProvider with existing data before strand is set, and add legacy behavior that TabBar.dataProvider doesn't have to be MX ViewStack

### DIFF
--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/beads/controllers/TabBarController.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/beads/controllers/TabBarController.as
@@ -58,6 +58,7 @@ import org.apache.royale.core.IViewport;
             _strand = value;
             var eventDispatcher:IEventDispatcher = (_strand.getBeadByType(IViewport) as IViewport).contentView as IEventDispatcher;
             eventDispatcher.addEventListener("itemsCreated", handleDataProviderChanged);
+            handleDataProviderChanged(null);
         }
         
         private function clickHandler(event:org.apache.royale.events.MouseEvent):void
@@ -68,6 +69,16 @@ import org.apache.royale.core.IViewport;
             if (list is ISelectableList)
             {
                 (list as ISelectableList).selectedIndex = index;
+            }
+            else
+            {
+                // legacy behavior
+                var tabbar:ListBase = _strand as ListBase;
+                if (tabbar)
+                {
+                    tabbar.selectedIndex = index;
+                    tabbar.dispatchEvent(new Event("selectedIndexChanged"));
+                }
             }
         }
         


### PR DESCRIPTION
Handle dataProvider with existing data before strand is set, and add legacy behavior that TabBar.dataProvider doesn't have to be MX ViewStack (though, selected event is currently different).

If TabBar.dataProvider is not MX ViewStack, then in legacy behavior, a click would send a valueCommit (event name for Bindable ListBase.selectedIndex) which could be picked up in a bind on TabBar.selectedIndex.  But that happened through commitSelection() / commitProperties() in ListBase, and those are not available in Royale.  This PR sends a selectedIndexChange event, but maybe that should be adjusted.