### PR TITLE
Fix IBeadView for Spark DataGroup, and add missing "implements ILayoutView" to Spark GroupBase.

### DIFF
--- a/frameworks/projects/SparkRoyale/src/main/resources/defaults.css
+++ b/frameworks/projects/SparkRoyale/src/main/resources/defaults.css
@@ -70,7 +70,7 @@ DataGroup
 {
 	IDataProviderItemRendererMapper: ClassReference("mx.controls.listClasses.DataItemRendererFactoryForIListData");
 	IBeadModel: ClassReference("mx.controls.beads.models.SingleSelectionIListModel");
-	IBeadView:  ClassReference("org.apache.royale.html.beads.DataContainerView");			
+	IBeadView:  ClassReference("spark.components.beads.DataContainerView");			
 	IBeadLayout: ClassReference("spark.layouts.supportClasses.SparkLayoutBead");
 	IItemRendererClassFactory: ClassReference("org.apache.royale.core.ItemRendererClassFactory");
 	IItemRenderer: ClassReference("spark.components.beads.SelfItemRenderer");
@@ -295,14 +295,12 @@ TitleWindow
     {
 	    IBackgroundBead: ClassReference("org.apache.royale.html.beads.SolidBackgroundBead");
 	    IBorderBead: ClassReference("org.apache.royale.html.beads.SingleLineBorderBead");
-	    IContentView: ClassReference("org.apache.royale.html.supportClasses.ContainerContentArea");
     }
 
 	SkinnableDataContainer
 	{
 		IBackgroundBead: ClassReference("org.apache.royale.html.beads.SolidBackgroundBead");
 		IBorderBead: ClassReference("org.apache.royale.html.beads.SingleLineBorderBead");
-		IContentView: ClassReference("org.apache.royale.html.supportClasses.DataGroup");
 	}
 
 	Label

--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/supportClasses/GroupBase.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/supportClasses/GroupBase.as
@@ -49,6 +49,7 @@ import org.apache.royale.core.IBeadLayout;
 import org.apache.royale.core.IContainer;
 import org.apache.royale.core.ILayoutHost;
 import org.apache.royale.core.ILayoutParent;
+import org.apache.royale.core.ILayoutView;
 import org.apache.royale.core.IParent;
 import org.apache.royale.core.ValuesManager;
 import org.apache.royale.events.Event;
@@ -333,7 +334,7 @@ include "../../styles/metadata/SelectionFormatTextStyles.as" */
  *  @playerversion AIR 1.5
  *  @productversion Royale 0.9.4
  */
-public class GroupBase extends UIComponent implements ILayoutParent, IContainer, IViewport
+public class GroupBase extends UIComponent implements ILayoutParent, ILayoutView, IContainer, IViewport
 {
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Reason that Spark GroupBase worked was because (JS) Basic ContainerView.get contentView() has a @royaleignorecoercion for ILayoutView, and GroupBase just happens to implement all of the methods of ILayoutView.

Also removed wrong IContentView from SWF CSS of Skinnable containers.