### PR TITLE
Under Spark, systemManager can be null in UITextFormat.measure()

### DIFF
--- a/frameworks/projects/MXRoyale/src/main/royale/mx/core/UITextFormat.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/core/UITextFormat.as
@@ -574,11 +574,11 @@ public class UITextFormat extends TextFormat
         var measuringElement:HTMLSpanElement = measuringElementRef;
 
         if (!measuringElement) {
-            measuringElementRef = (systemManager as SystemManager).measuringElement;
+            measuringElementRef = (systemManager ? (systemManager as SystemManager).measuringElement : null);
             measuringElement = measuringElementRef;
             if (!measuringElement) {
                 var sm:SystemManager = systemManager as SystemManager;
-                if (sm.measuringElement == null)
+                if (!sm || sm.measuringElement == null)
                 {
                     measuringElement = document.createElement("span") as HTMLSpanElement;
                     //everything else is absolute position so should be above this element
@@ -587,8 +587,8 @@ public class UITextFormat extends TextFormat
                     //sm.measuringElement.style.display = "none"; // to try to keep it hidden
                     measuringElement.style.opacity = 0;
                     measuringElement.style["pointer-events"] = "none";
-                    sm.element.appendChild(measuringElement);
-                    sm.measuringElement = measuringElement;
+                    if (sm) sm.element.appendChild(measuringElement);
+                    if (sm) sm.measuringElement = measuringElement;
                 }
             }
         }


### PR DESCRIPTION
For whatever reason, systemManager can be null in the context of UITextFormat.measure() while running under Spark.  (I think this was primarily in MX ADG, but I can't remember exactly.)

So this PR just makes a standalone measuringElement, in that case.

Perhaps there's a better way of dealing with it than this.  Or systemManager is supposed to not be null here?  Open to any ideas.