### PR TITLE
Create bead Spark TabBarSelectionUpdateFromSelectableDataProvider to propagate MX ViewStack.selectedIndex change to Spark TabBar.

### DIFF
--- a/frameworks/projects/MXRoyale/src/main/royale/mx/core/UIComponent.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/core/UIComponent.as
@@ -97,6 +97,7 @@ import org.apache.royale.geom.Rectangle;
 import org.apache.royale.html.beads.DisableBead;
 import org.apache.royale.html.beads.DisabledAlphaBead;
 import org.apache.royale.html.supportClasses.ContainerContentArea;
+import org.apache.royale.reflection.getQualifiedClassName;
 import org.apache.royale.utils.PointUtils;
 import org.apache.royale.utils.CSSUtils;
 import org.apache.royale.utils.loadBeadFromValuesManager;
@@ -988,7 +989,6 @@ public class UIComponent extends UIBase
      *  @playerversion Flash 9
      *  @playerversion AIR 1.1
      *  @productversion Flex 3
-     *  @royaleignorecoercion mx.core.IUIComponent
      */
     COMPILE::JS
     public function get name():String
@@ -1425,7 +1425,7 @@ public class UIComponent extends UIBase
      *  @playerversion Flash 9
      *  @playerversion AIR 1.1
      *  @productversion Flex 3
-     *  @royaleignorecoercion mx.core.IUIComponent
+     *  @royaleemitcoercion mx.core.IUIComponent
      */
     public function get owner():IUIComponent
     {
@@ -2404,6 +2404,8 @@ COMPILE::JS
                         var child:IUIComponent = getChildAt(i);
                         if (child) // child is null for TextNodes
                             mw = Math.max(mw, child.getExplicitOrMeasuredWidth());
+                        else
+                            trace("Child class not IUIComponent: " + getQualifiedClassName(getElementAt(i)));
                     }
                 }
                 if (oldWidth.length)
@@ -2478,6 +2480,8 @@ COMPILE::JS
                         var child:IUIComponent = getChildAt(i);
                         if (child)
                             mh = Math.max(mh, child.getExplicitOrMeasuredHeight());
+                        else
+                            trace("Child class not IUIComponent: " + getQualifiedClassName(getElementAt(i)));
                     }
                 }
                 if (oldHeight.length)
@@ -3583,66 +3587,63 @@ COMPILE::JS
 
     /**
      *  @private
-     *  @royaleignorecoercion mx.core.IUIComponent
      */
     [SWFOverride(params="flash.display.DisplayObject", altparams="mx.core.UIComponent", returns="flash.display.DisplayObject"))]
     COMPILE::SWF 
     { override }
     public function addChild(child:IUIComponent):IUIComponent
     {
-        return addElement(child) as IUIComponent;
+        addElement(child);
+        return child;
     }
     
     
     public function $uibase_addChild(child:IUIComponent):IUIComponent
     {
         // this should avoid calls to addingChild/childAdded
-        var ret:IUIComponent = super.addElement(child) as IUIComponent;
-        return ret;
+        super.addElement(child);
+        return child;
     }
 
     /**
      *  @private
-     *  @royaleignorecoercion mx.core.IUIComponent
      */
     [SWFOverride(params="flash.display.DisplayObject,int", altparams="mx.core.UIComponent,int", returns="flash.display.DisplayObject"))]
     COMPILE::SWF 
     { override }
-    public function addChildAt(child:IUIComponent,
-                                        index:int):IUIComponent
+    public function addChildAt(child:IUIComponent, index:int):IUIComponent
     {
-        return addElementAt(child, index) as IUIComponent;
+        addElementAt(child, index);
+        return child;
     }
     
-    public function $uibase_addChildAt(child:IUIComponent,
-                               index:int):IUIComponent
+    public function $uibase_addChildAt(child:IUIComponent, index:int):IUIComponent
     {
-        var ret:IUIComponent;
         // this should avoid calls to addingChild/childAdded
         if (index >= super.numElements)
-            ret = super.addElement(child) as IUIComponent;
+            super.addElement(child);
         else
-            ret = super.addElementAt(child, index) as IUIComponent;
-        return ret;
+            super.addElementAt(child, index);
+        return child;
     }
 
     /**
      *  @private
-     *  @royaleignorecoercion mx.core.IUIComponent
      */
     [SWFOverride(params="flash.display.DisplayObject", altparams="mx.core.UIComponent", returns="flash.display.DisplayObject"))]
     COMPILE::SWF 
     { override }
     public function removeChild(child:IUIComponent):IUIComponent
     {
-        return removeElement(child) as IUIComponent;
+        removeElement(child)
+        return child;
     }
     
     public function $uibase_removeChild(child:IUIComponent):IUIComponent
     {
         // this should probably call the removingChild/childRemoved
-        var ret:IUIComponent = super.removeElement(child) as IUIComponent;
-        return ret;
+        super.removeElement(child);
+        return child;
     }
     
     COMPILE::JS
@@ -3650,28 +3651,35 @@ COMPILE::JS
 	{
 	
 	}
+
     /**
      *  @private
-     *  @royaleignorecoercion mx.core.IUIComponent
+     *  @royaleemitcoercion mx.core.IUIComponent
      */
     [SWFOverride(returns="flash.display.DisplayObject"))]
     COMPILE::SWF 
     { override }
     public function removeChildAt(index:int):IUIComponent
     {
+        var child:IUIComponent = getElementAt(index) as IUIComponent;
         // this should probably call the removingChild/childRemoved
-        return removeElement(getElementAt(index)) as IUIComponent;
+        removeElement(child);
+        return child;
     }
     
+    /**
+     *  @royaleemitcoercion mx.core.IUIComponent
+     */
     public function $uibase_removeChildAt(index:int):IUIComponent
     {
-        var ret:IUIComponent = super.removeElement(getElementAt(index)) as IUIComponent;
-        return ret;
+        var child:IUIComponent = getElementAt(index) as IUIComponent;
+        super.removeElement(child);
+        return child;
     }
 
     /**
      *  @private
-     *  @royaleignorecoercion mx.core.IUIComponent
+     *  @royaleemitcoercion mx.core.IUIComponent
      */
     [SWFOverride(returns="flash.display.DisplayObject"))]
     COMPILE::SWF 
@@ -6280,8 +6288,6 @@ COMPILE::JS
      *  @playerversion Flash 10.2
      *  @playerversion AIR 2.6
      *  @productversion Royale 0.0
-     *  @royaleignorecoercion org.apache.royale.core.WrappedHTMLElement
-     *  @royaleignorecoercion org.apache.royale.events.IEventDispatcher
      */
     override public function get topMostEventDispatcher():IEventDispatcher
     {

--- a/frameworks/projects/SparkRoyale/src/main/resources/spark-royale-manifest.xml
+++ b/frameworks/projects/SparkRoyale/src/main/resources/spark-royale-manifest.xml
@@ -142,6 +142,7 @@
     <component id="Sort" class="spark.collections.Sort"/>
     <component id="SortField" class="spark.collections.SortField"/>
     <component id="CollectionChangeUpdateForArrayListData" class="spark.components.beads.CollectionChangeUpdateForArrayListData" />
+    <component id="TabBarSelectionUpdateFromSelectableDataProvider" class="spark.components.beads.TabBarSelectionUpdateFromSelectableDataProvider"/>
     <component id="SelfItemRenderer" class="spark.components.beads.SelfItemRenderer"/>
     <component id="SelfItemRendererInitializer" class="spark.components.beads.SelfItemRendererInitializer"/>
 

--- a/frameworks/projects/SparkRoyale/src/main/royale/SparkRoyaleClasses.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/SparkRoyaleClasses.as
@@ -97,6 +97,7 @@ internal class SparkRoyaleClasses
     import spark.components.beads.SparkSkinScrollingViewport; SparkSkinScrollingViewport;
 	import spark.components.beads.SparkSkinWithClipAndEnableScrollingViewport; SparkSkinWithClipAndEnableScrollingViewport;
     import spark.components.beads.CollectionChangeUpdateForArrayListData; CollectionChangeUpdateForArrayListData;
+	import spark.components.beads.TabBarSelectionUpdateFromSelectableDataProvider; TabBarSelectionUpdateFromSelectableDataProvider;
     import spark.components.beads.DropDownListView; DropDownListView;
     import spark.components.beads.TitleWindowView; TitleWindowView;
     import spark.components.beads.controllers.DropDownListController; DropDownListController;

--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/beads/TabBarSelectionUpdateFromSelectableDataProvider.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/beads/TabBarSelectionUpdateFromSelectableDataProvider.as
@@ -1,0 +1,158 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+package spark.components.beads
+{
+	import org.apache.royale.core.IBead;
+	import org.apache.royale.core.IDataProviderModel;
+	import org.apache.royale.core.IStrand;
+	import org.apache.royale.core.IViewport;
+	import org.apache.royale.events.Event;
+	import org.apache.royale.events.IEventDispatcher;
+	import mx.core.ISelectableList;
+	import spark.components.TabBar;
+
+
+    /**
+	 *  Updates TabBar.selectedIndex when the selectable dataProvider (i.e. ViewStack)
+	 *  has a selectedIndex change.
+	 *
+	 *  @langversion 3.0
+	 *  @playerversion Flash 10.2
+	 *  @playerversion AIR 2.6
+	 *  @productversion Royale 0.9.8
+	 */
+	public class TabBarSelectionUpdateFromSelectableDataProvider implements IBead
+	{
+		/**
+		 *  Constructor
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10.2
+		 *  @playerversion AIR 2.6
+		 *  @productversion Royale 0.9.8
+		 */
+		public function TabBarSelectionUpdateFromSelectableDataProvider()
+		{
+		}
+
+		protected var _strand:IStrand;
+
+		/**
+		 *  @copy org.apache.royale.core.IStrand
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10.2
+		 *  @playerversion AIR 2.6
+		 *  @productversion Royale 0.9.8
+		 *  @royaleignorecoercion org.apache.royale.events.IEventDispatcher
+		 */
+		public function set strand(value:IStrand):void
+		{
+			_strand = value;
+			IEventDispatcher(value).addEventListener("initComplete", initComplete);
+		}
+
+		/**
+		 *  finish setup
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10.2
+		 *  @playerversion AIR 2.6
+		 *  @productversion Royale 0.9.8
+		 *  @royaleignorecoercion org.apache.royale.core.IDataProviderModel
+		 */
+		protected function initComplete(event:Event):void
+		{
+			IEventDispatcher(_strand).removeEventListener("initComplete", initComplete);
+
+			var contentView:IStrand = (_strand.getBeadByType(IViewport) as IViewport).contentView as IStrand;
+			_dataProviderModel = contentView.getBeadByType(IDataProviderModel) as IDataProviderModel;
+
+			dataProviderModel.addEventListener("dataProviderChanged", dataProviderChangeHandler);
+
+			// invoke now in case "dataProviderChanged" has already been dispatched.
+			dataProviderChangeHandler(null);
+		}
+
+		private var dp:ISelectableList;
+
+		/**
+		 * @private
+		 * @royaleignorecoercion org.apache.royale.events.IEventDispatcher
+		 */
+		protected function dataProviderChangeHandler(event:Event):void
+		{
+			if (dp)
+			{
+				dp.removeEventListener("change", handleIndexChange);
+				dp.removeEventListener("valueCommit", handleIndexChange);
+			}
+
+			dp = dataProviderModel.dataProvider as ISelectableList;
+			if (!dp) return;
+
+			dp.addEventListener("change", handleIndexChange);
+			dp.addEventListener("valueCommit", handleIndexChange);
+			
+			handleIndexChange(null);
+		}
+
+		/**
+		 *  Handles the selectedIndex change event.
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10.2
+		 *  @playerversion AIR 2.6
+		 *  @productversion Royale 0.9.8
+		 *  @royaleignorecoercion org.apache.royale.events.IEventDispatcher
+		 */
+		protected function handleIndexChange(event:Event):void
+		{
+			var tb:TabBar = _strand as TabBar;
+			var newSelectedIndex:int = dp.selectedIndex;
+			if (tb.selectedIndex != newSelectedIndex)
+			{
+				tb.selectedIndex = newSelectedIndex;
+			}
+		}
+
+		private var _dataProviderModel:IDataProviderModel;
+
+		/**
+		 *  The org.apache.royale.core.IDataProviderModel that contains the
+		 *  data source.
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10.2
+		 *  @playerversion AIR 2.6
+		 *  @productversion Royale 0.9.8
+		 *  @royaleignorecoercion org.apache.royale.core.IDataProviderModel
+		 */
+		public function get dataProviderModel():IDataProviderModel
+		{
+			if (!_dataProviderModel)
+			{
+				var contentView:IStrand = (_strand.getBeadByType(IViewport) as IViewport).contentView as IStrand;
+				_dataProviderModel = contentView.getBeadByType(IDataProviderModel) as IDataProviderModel;
+			}
+			return _dataProviderModel;
+		}
+		
+	}
+}


### PR DESCRIPTION
Create bead Spark TabBarSelectionUpdateFromSelectableDataProvider to propagate MX ViewStack.selectedIndex change to Spark TabBar.

This is legacy behavior that normally would get into TabBar through ButtonBarBase, but TabBar doesn't inherit from that anymore.
