### PR TITLE
Add MX System.setClipboard()

### DIFF
--- a/frameworks/projects/MXRoyale/src/main/royale/MXRoyaleClasses.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/MXRoyaleClasses.as
@@ -90,6 +90,7 @@ internal class MXRoyaleClasses
 	import mx.core.Container;Container;
 
 	import mx.system.ApplicationDomain; ApplicationDomain;
+	import mx.system.System; System;
 	import mx.rpc.http.HTTPService; mx.rpc.http.HTTPService;
 	import mx.rpc.remoting.RemoteObject; mx.rpc.remoting.RemoteObject;
 	import mx.rpc.remoting.CompressedRemoteObject; mx.rpc.remoting.CompressedRemoteObject;

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/system/System.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/system/System.as
@@ -1,0 +1,83 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package mx.system
+{
+	COMPILE::SWF
+	{
+		import flash.system.System;
+	}
+
+	/**
+	 *  
+	 *  @langversion 3.0
+	 *  @playerversion Flash 9
+	 *  @playerversion AIR 1.0
+	 *  @productversion Royale 0.9.8
+	 */
+
+	public class System
+	{
+		/**
+		 *  Constructor.
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 9
+		 *  @playerversion AIR 1.0
+		 *  @productversion Royale 0.9.8
+		 */
+
+		public function System()
+		{
+		}
+		
+		/**
+		 *  Replaces the contents of the Clipboard with a specified text string.
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 9
+		 *  @playerversion AIR 1.0
+		 *  @productversion Royale 0.9.8
+		 */
+
+		public static function setClipboard(str:String):void
+		{
+			COMPILE::SWF
+			{
+				flash.system.System.setClipboard(str);
+			}
+			
+			COMPILE::JS
+			{
+				var span:HTMLSpanElement = document.createElement("span") as HTMLSpanElement;
+				span.innerText = str;
+				span.id = "copyToClipboard";
+				document.body.appendChild( span );
+				var copyToClipboard:Element = document.getElementById("copyToClipboard");
+				var selection:Selection = window.getSelection();
+				var range:Range = document.createRange();
+				range.selectNodeContents(copyToClipboard);
+				selection.removeAllRanges();
+				selection.addRange(range);
+				document.execCommand("copy");
+				document.body.removeChild( span );
+			}
+		}
+	}
+}


### PR DESCRIPTION
For issue #1022.

The way the JS code adds an element to the DOM and uses it for the copy may cause the content to show on the screen for an instant.  That part could be improved.