### PR TITLE
Fix word-wrapping in Spark TabBar tab labels

### DIFF
--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/supportClasses/SparkTextButtonItemRenderer.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/supportClasses/SparkTextButtonItemRenderer.as
@@ -48,6 +48,10 @@ package spark.components.supportClasses
         {
             super();
             addEventListener("click", clickHandler);    
+            COMPILE::JS
+            {
+            	element.style.whiteSpace = "nowrap";
+            }
             typeNames += " SparkTextButtonItemRenderer";
         }
             


### PR DESCRIPTION
Fix word-wrapping in Spark TabBar tab labels, causing measuring to be wrong for layouts involving labels with hyphens (-) and whitespace.

What was strange was that word-wrapping on whitespace, or word-breaking on hyphens, sometimes happened and sometimes did not, depending on the MXML definition.  No idea why;  should have always happened.

Closes #967.