### PR TITLE
Fix height too small for Spark TabBar tab labels on Chrome

### DIFF
--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/DataGroup.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/DataGroup.as
@@ -202,7 +202,7 @@ public class DataGroup extends GroupBase implements IItemRendererProvider, IStra
         var presModel:IListPresentationModel = getBeadByType(IListPresentationModel) as IListPresentationModel;
         if (presModel == null) {
             presModel = new ListPresentationModel();
-            presModel.rowHeight = 18;
+            presModel.rowHeight = 20;
             addBead(presModel);
         }
         return presModel;


### PR DESCRIPTION
Was fine on Firefox, but on Chrome, showed horizontal scroll bar, obscuring the tab labels.  Adding 1 to the height fixed the issue, but for this fix, added 2, as it seemed more appropriate (even number, and on Chrome, button seems to extend a few pixels lower).  The box-sizing style had already been applied appropriately, so there is some other reason why Chrome requires 1 more pixel.