### PR TITLE
Completed 'todo' item: allow amf0 bead to upgrade to amf3 encoding

### DIFF
--- a/frameworks/projects/Network/src/main/royale/org/apache/royale/net/remoting/amf/AMF0AMF3Context.as
+++ b/frameworks/projects/Network/src/main/royale/org/apache/royale/net/remoting/amf/AMF0AMF3Context.as
@@ -37,8 +37,8 @@ package org.apache.royale.net.remoting.amf {
 			AMFBinaryData.installAlternateContext(AMF0AMF3Context);
 		}
 
-		//@todo :
 		private static const AMF0_AMF3:int = 0x11;
+		private var switchedToAMF3 = false;
 
 		private static const AMF0_NUMBER:uint = 0x0;
 		private static const AMF0_BOOLEAN:uint =0x1;
@@ -66,6 +66,11 @@ package org.apache.royale.net.remoting.amf {
 
 		override public function supportsAMFEncoding(type:uint):Boolean{
 			return type == 3 || type == 0;
+		}
+
+		override public function reset():void {
+			super.reset();
+			switchedToAMF3 = false;
 		}
 
 		/*override public function writeObject(v:*):void {
@@ -337,8 +342,17 @@ package org.apache.royale.net.remoting.amf {
 		}*/
 
 		override public function readAmf0Object():* {
-			var amfType:uint = readUnsignedByte();
-			return readAmf0ObjectValue(amfType);
+			if (switchedToAMF3) {
+				return readAmf3Object();
+			} else {
+				var amfType:uint = readUnsignedByte();
+				if (amfType == AMF0_AMF3) {
+					switchedToAMF3 = true;
+					return readAmf3Object();
+				} else {
+					return readAmf0ObjectValue(amfType);
+				}
+			}
 		}
 
 		private function readAmf0ObjectValue(amfType:uint):Object {

--- a/frameworks/projects/Network/src/main/royale/org/apache/royale/net/remoting/amf/AMF0AMF3Context.as
+++ b/frameworks/projects/Network/src/main/royale/org/apache/royale/net/remoting/amf/AMF0AMF3Context.as
@@ -38,7 +38,7 @@ package org.apache.royale.net.remoting.amf {
 		}
 
 		private static const AMF0_AMF3:int = 0x11;
-		private var switchedToAMF3 = false;
+		private var switchedToAMF3:Boolean = false;
 
 		private static const AMF0_NUMBER:uint = 0x0;
 		private static const AMF0_BOOLEAN:uint =0x1;

--- a/frameworks/projects/Network/src/main/royale/org/apache/royale/net/remoting/amf/AMFContext.as
+++ b/frameworks/projects/Network/src/main/royale/org/apache/royale/net/remoting/amf/AMFContext.as
@@ -126,7 +126,7 @@ internal class AMFContext extends BinaryData implements IDataInput, IDataOutput,
 		super();
 	}
 
-	public function reset():void {
+	override public function reset():void {
 		writeBuffer = [];
 		objects = [];
 		traits = {};

--- a/frameworks/projects/Network/src/main/royale/org/apache/royale/net/remoting/amf/AMFContext.as
+++ b/frameworks/projects/Network/src/main/royale/org/apache/royale/net/remoting/amf/AMFContext.as
@@ -126,7 +126,7 @@ internal class AMFContext extends BinaryData implements IDataInput, IDataOutput,
 		super();
 	}
 
-	override public function reset():void {
+	public function reset():void {
 		writeBuffer = [];
 		objects = [];
 		traits = {};


### PR DESCRIPTION
Adds functionality marked 'todo' in the source.

There are 2 data encodings used by AMF: AMF0 and AMF3. Royale supports AMF3 by default and AMF0 via the AMF0AMF3Context bead. There is a complication in the AMF0 encoding, which is that it can upgrade from AMF0 to AMF3 midway through a read (or write), and this change implements that for reads.

I also added an override of the base class reset function which switches the `switchedToAMF3` state variable back to false if `reset()` is called, so in the future if the code is extended to handle multiple reads it should call `reset()` at the beginning of each read.

This has been tested against the existing unit tests, and our (my employer's) production AMF service which requires every combination you can think of, including AMF0->AMF3 upgrade.