### PR TITLE
Set AMF context to correct encoding

### DIFF
--- a/frameworks/projects/Network/src/main/royale/org/apache/royale/net/remoting/amf/AMFNetConnection.as
+++ b/frameworks/projects/Network/src/main/royale/org/apache/royale/net/remoting/amf/AMFNetConnection.as
@@ -452,7 +452,7 @@ public class AMFNetConnection
 
     COMPILE::JS
     private function readMessage(reader:AMFBinaryData):ActionMessage
-    {   
+    {
         var message:ActionMessage = new ActionMessage();
         message.version = reader.readUnsignedShort();
         reader.objectEncoding = message.version;

--- a/frameworks/projects/Network/src/main/royale/org/apache/royale/net/remoting/amf/AMFNetConnection.as
+++ b/frameworks/projects/Network/src/main/royale/org/apache/royale/net/remoting/amf/AMFNetConnection.as
@@ -452,9 +452,10 @@ public class AMFNetConnection
 
     COMPILE::JS
     private function readMessage(reader:AMFBinaryData):ActionMessage
-    {
+    {   
         var message:ActionMessage = new ActionMessage();
         message.version = reader.readUnsignedShort();
+        reader.objectEncoding = message.version;
         var headerCount:uint = reader.readUnsignedShort();
         for (var i:uint = 0; i < headerCount; i++) {
             message.headers.push(this.readHeader(reader));


### PR DESCRIPTION
This fix does two things:

1. the current code will probably crash if a read of an AMF0 encoded message is attempted, as the reader assumes AMF3, and nothing I can see changes that, including using the AMF0AMF3Context bead. This fix ensures that when the encoding type (0 or 3) is read from the message, the subsequent read is carried out using that encoding.

2. the second benefit is customer experience. Without the bead, the existing code outputs an error that gives no clue to the nature of the underlying problem - this is the reason I have gone down this particular rabbit hole. With this fix, if an AMF0 message is read, this error is output when reading AMF0: `AMF0 support is unimplemented by default, supported via bead`. With the bead in use, this fix does nothing beyond simply allowing the data to be read correctly.