### PR TITLE
Use AMFNetConnection.call()'s command parameter for the AMF targetURI

### DIFF
--- a/frameworks/projects/Network/src/main/royale/org/apache/royale/net/remoting/amf/AMFNetConnection.as
+++ b/frameworks/projects/Network/src/main/royale/org/apache/royale/net/remoting/amf/AMFNetConnection.as
@@ -301,6 +301,7 @@ public class AMFNetConnection
             requestQueue.push(
                     {
                         url: url,
+                        targetURI: command,
                         responder: responder,
                         args: params
                     }
@@ -328,6 +329,7 @@ public class AMFNetConnection
             var actionMessage:ActionMessage = new ActionMessage();
             var messageBody:MessageBody = new MessageBody();
             sequence++;
+            messageBody.targetURI = call.item.targetURI;
             messageBody.responseURI = "/" + sequence.toString();
             messageBody.data = args;
             actionMessage.bodies = [ messageBody ];


### PR DESCRIPTION
@greg-dove @carlosrovira This is a second attempt to fix what I tried to fix in pull request https://github.com/apache/royale-asjs/pull/1023, which was subsequently reverted after problems with the examples. This fix addresses the targetURI issue without breaking existing code.

The problem this fix solves: in `AMFNetComponenent.onReadyStateChange()`, the message is encoded and sent without ever setting `messageBody.targetURI`, and the default value `"null"` is always used.

To refresh our memories, here is the explanation of the `NetConnection.call()` `command` parameter from the Adobe AS3 help:

> command:String — A method specified in the form `[objectPath/]method`. For example, the `someObject/doSomething` command tells the remote server to call the `clientObject.someObject.doSomething()` method, with all the optional ... arguments parameters. If the object path is missing, `clientObject.doSomething()` is invoked on the remote server.

My solution: allow the targetURI value to be passed in in the `AMFNetComponenent.call()` `command` parameter, in line with how it was invoked under flex in the past. This is stored in the `item` object and queued, and passed eventually to `AMFNetComponenent.onReadyStateChange()` where the value is used to correctly set `messageBody.targetURI`.

I cannot find any instances in the royale code base where a value of anything other than null is passed into this parameter, so existing functionality will not be affected by this change.

Unfortunately - I have been unable to get the `SampleAMFWebApp` test application to run for love or money, though it builds fine, so I have been unable to definitively test that the examples work. I have eyballed the code carefully. I put the certainty that this doesn't break anything at 90%, but I have run out of time to debug the web server given the current pressure I am under on porting our app. If you have a working setup with a functional `SampleAMFWebApp` it would be really great if you could confirm that all is well prior to merging.

FYI in my previous attempt I made a change to the `NetConnection.call()` design. This solution doesn't mess with that - I found I am able to address my issue by using `AMFNetConnection` instead of `NetConnection`.