### PR TITLE
Update TextInput.as

### DIFF
--- a/frameworks/projects/MXRoyale/src/main/royale/mx/controls/TextInput.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/controls/TextInput.as
@@ -659,12 +659,7 @@ public class TextInput extends UIComponent implements ITextInput
         _editable = value;
 	COMPILE::JS
 	{
-		if(value == false) {
-			(element as HTMLInputElement).readOnly = true;
-		}
-		else {
-			 (element as HTMLInputElement).readOnly = value;
-		}
+		(element as HTMLInputElement).readOnly = !value;
 	}
 	
      /*   if (value == _editable)


### PR DESCRIPTION
Fixed issue when value is "true" the readOnly attribute is set to "true", instead of "false".