### PR TITLE
jewel-daterangerestriction: Replace time calculation with appropriate filters per view state

### DIFF
--- a/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/controls/datechooser/DateChooserDateRangeRestriction.as
+++ b/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/controls/datechooser/DateChooserDateRangeRestriction.as
@@ -18,19 +18,20 @@
 ////////////////////////////////////////////////////////////////////////////////
 package org.apache.royale.jewel.beads.controls.datechooser
 {
-    import org.apache.royale.core.DispatcherBead;
-    import org.apache.royale.core.IStrand;
-    import org.apache.royale.events.Event;
-    import org.apache.royale.events.IEventDispatcher;
-    import org.apache.royale.events.MouseEvent;
-    import org.apache.royale.jewel.beads.controls.Disabled;
-    import org.apache.royale.jewel.beads.itemRenderers.ITextItemRenderer;
-    import org.apache.royale.jewel.beads.views.DateChooserView;
-    import org.apache.royale.jewel.supportClasses.datechooser.DateChooserTable;
-    import org.apache.royale.jewel.supportClasses.table.TBodyContentArea;
-    import org.apache.royale.jewel.supportClasses.table.TableCell;
-    import org.apache.royale.jewel.supportClasses.table.TableRow;
-													
+	import org.apache.royale.core.DispatcherBead;
+	import org.apache.royale.core.IStrand;
+	import org.apache.royale.events.Event;
+	import org.apache.royale.events.IEventDispatcher;
+	import org.apache.royale.events.MouseEvent;
+	import org.apache.royale.jewel.beads.controls.Disabled;
+	import org.apache.royale.jewel.beads.itemRenderers.ITextItemRenderer;
+	import org.apache.royale.jewel.beads.models.DateChooserModel;
+	import org.apache.royale.jewel.beads.views.DateChooserView;
+	import org.apache.royale.jewel.supportClasses.datechooser.DateChooserTable;
+	import org.apache.royale.jewel.supportClasses.table.TBodyContentArea;
+	import org.apache.royale.jewel.supportClasses.table.TableCell;
+	import org.apache.royale.jewel.supportClasses.table.TableRow;
+
 	/**
 	 *  Disable dates which are outside restriction provided by minDate and maxDate properties
 	 *  in DateChooser component. User can set just one restriction (minDate or maxDate), or both
@@ -47,7 +48,7 @@ package org.apache.royale.jewel.beads.controls.datechooser
 	 */
 	public class DateChooserDateRangeRestriction extends DispatcherBead
 	{
-        /**
+		/**
 		 *  constructor.
 		 *
 		 *  @langversion 3.0
@@ -58,16 +59,16 @@ package org.apache.royale.jewel.beads.controls.datechooser
 		public function DateChooserDateRangeRestriction()
 		{
 		}
-		
+
 		private var _minDate:Date;
-        /**
-         *  The minimun date
-         *
-         *  @langversion 3.0
-         *  @playerversion Flash 10.2
-         *  @playerversion AIR 2.6
-         *  @productversion Royale 0.9.8
-         */
+		/**
+		 *  The minimun date
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10.2
+		 *  @playerversion AIR 2.6
+		 *  @productversion Royale 0.9.8
+		 */
 		[Bindable]
 		public function get minDate():Date
 		{
@@ -81,16 +82,16 @@ package org.apache.royale.jewel.beads.controls.datechooser
 				refreshDateRange();
 			}
 		}
-		
+
 		private var _maxDate:Date;
-        /**
-         *  The maximun date
-         *
-         *  @langversion 3.0
-         *  @playerversion Flash 10.2
-         *  @playerversion AIR 2.6
-         *  @productversion Royale 0.9.8
-         */
+		/**
+		 *  The maximun date
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10.2
+		 *  @playerversion AIR 2.6
+		 *  @productversion Royale 0.9.8
+		 */
 		[Bindable]
 		public function get maxDate():Date
 		{
@@ -104,7 +105,7 @@ package org.apache.royale.jewel.beads.controls.datechooser
 				refreshDateRange();
 			}
 		}
-		
+
 		/**
 		 *  @copy org.apache.royale.core.IBead#strand
 		 *  
@@ -116,10 +117,11 @@ package org.apache.royale.jewel.beads.controls.datechooser
 		 */
 		public override function set strand(value:IStrand):void
 		{
-            super.strand = value;
+			super.strand = value;
 			(_strand as IEventDispatcher).addEventListener("initComplete", handleDateChooserInitComplete);
 		}
 
+		private var model:DateChooserModel;
 		private var view:DateChooserView;
 		private var table:DateChooserTable;
 		private var tableContent:TBodyContentArea;
@@ -132,67 +134,119 @@ package org.apache.royale.jewel.beads.controls.datechooser
 
 		public function setUpBead():void
 		{
+			model = _strand.getBeadByType(DateChooserModel) as DateChooserModel;
+
 			view = _strand.getBeadByType(DateChooserView) as DateChooserView;
 			view.previousButton.addEventListener(MouseEvent.CLICK, refreshDateRange);
 			view.nextButton.addEventListener(MouseEvent.CLICK, refreshDateRange);
 			view.viewSelector.addEventListener(MouseEvent.CLICK, refreshDateRange);
-            
+
 			refreshDateRange();
 		}
-		
+
 		public function refreshDateRange():void
 		{
-			if(!view) return;
-            if (!minDate && !maxDate) return;
+			if (!view)
+				return;
 
-			if(view.table)
+			if (view.table)
 				view.table.removeEventListener(Event.CHANGE, refreshDateRange);
 			table = view.table;
 			view.table.addEventListener(Event.CHANGE, refreshDateRange);
-            tableContent = table.getBeadByType(TBodyContentArea) as TBodyContentArea;
-			
-            var n:int = table.dataProvider.length;
+			tableContent = table.getBeadByType(TBodyContentArea) as TBodyContentArea;
+
+			var n:int = table.dataProvider.length;
 			for (var i:int = 0; i < tableContent.numElements; i++)
 			{
 				var row:TableRow = tableContent.getElementAt(i) as TableRow;
-			    for(var j:int = 0; j < row.numElements; j++)
+				for (var j:int = 0; j < row.numElements; j++)
 				{
-			        var tableCell:TableCell = row.getElementAt(j) as TableCell;
-			        var renderer:ITextItemRenderer  = tableCell.getElementAt(0) as ITextItemRenderer;
-                    disableRenderer(renderer);
-		        }
-		    }
-		}		
-		
+					var tableCell:TableCell = row.getElementAt(j) as TableCell;
+					var renderer:ITextItemRenderer  = tableCell.getElementAt(0) as ITextItemRenderer;
+					disableRenderer(renderer);
+				}
+			}
+		}
+
+		/**
+		 *  <code>true</code> if the date1's year is less than date2's year.
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10.2
+		 *  @playerversion AIR 2.6
+		 *  @productversion Royale 0.9.8
+		 */
+		private function isLessThanYear(date1:Date, date2:Date):Boolean
+		{
+			return date1.getYear() < date2.getYear();
+		}
+
+		/**
+		 *  <code>true</code> if the date1's month is less than date2's month.
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10.2
+		 *  @playerversion AIR 2.6
+		 *  @productversion Royale 0.9.8
+		 */
+		private function isLessThanMonth(date1:Date, date2:Date):Boolean
+		{
+			return date1.getYear() == date2.getYear() && date1.getMonth() < date2.getMonth();
+		}
+
+		/**
+		 *  <code>true</code> if the date1's day is less than date2's day.
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10.2
+		 *  @playerversion AIR 2.6
+		 *  @productversion Royale 0.9.8
+		 */
+		private function isLessThanDay(date1:Date, date2:Date):Boolean
+		{
+			return date1.getYear() == date2.getYear() && date1.getMonth() == date2.getMonth() && date1.getDate() < date2.getDate();
+		}
+
 		private function disableRenderer(renderer:ITextItemRenderer):void
 		{
 			var rendererDate:Date = renderer.data[renderer.labelField];
-            if (!rendererDate) return;
-			
-			var minTime:Number;
-			var maxTime:Number;
-			if(minDate) 
-				minTime = minDate.getTime();
-			if(maxDate) 
-				maxTime = maxDate.getTime();
-			var itemTime:Number = rendererDate.getTime();
-			
+			if (!rendererDate)
+				return;
+
 			var disabled:Disabled = (renderer as IStrand).getBeadByType(Disabled) as Disabled;
 			if (disabled == null)
 			{
-			    disabled = new Disabled();
+				disabled = new Disabled();
 				(renderer as IStrand).addBead(disabled);
 			}
 
-			if(minDate && maxDate)
-				// both minDate and maxDate
-				disabled.disabled = (itemTime > minTime) && (maxTime > itemTime) ? false : true;
-			else if(!minDate && maxDate)
-				// only maxDate
-				disabled.disabled = maxTime > itemTime ? false : true; 
-			else if(minDate && !maxDate)
-				// only minDate
-				disabled.disabled = itemTime > minTime ? false : true;
+			if (model.viewState == 0) // Day view
+			{
+				if (minDate && maxDate)
+					disabled.disabled = isLessThanDay(rendererDate, minDate) && isLessThanDay(maxDate, rendererDate);
+				else if (minDate)
+					disabled.disabled = isLessThanDay(rendererDate, minDate);
+				else if (maxDate)
+					disabled.disabled = isLessThanDay(maxDate, rendererDate);
+			}
+			else if (model.viewState == 1) // Year view
+			{
+				if (minDate && maxDate)
+					disabled.disabled = isLessThanYear(rendererDate, minDate) && isLessThanYear(maxDate, rendererDate);
+				else if (minDate)
+					disabled.disabled = isLessThanYear(rendererDate, minDate);
+				else if (maxDate)
+					disabled.disabled = isLessThanYear(maxDate, rendererDate);
+			}
+			else if (model.viewState == 2) // Month view
+			{
+				if (minDate && maxDate)
+					disabled.disabled = isLessThanMonth(rendererDate, minDate) && isLessThanMonth(maxDate, rendererDate);
+				else if (minDate)
+					disabled.disabled = isLessThanMonth(rendererDate, minDate);
+				else if (maxDate)
+					disabled.disabled = isLessThanMonth(maxDate, rendererDate);
+			}
 
 			// ensure no selection remains in dates out of the range
 			// if(disabled.disabled)
@@ -202,5 +256,5 @@ package org.apache.royale.jewel.beads.controls.datechooser
 			// 		selectionBead.selected = false;
 			// }
 		}
-    }
+	}
 }

--- a/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/controls/datefield/DateFieldDateRangeRestriction.as
+++ b/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/controls/datefield/DateFieldDateRangeRestriction.as
@@ -18,18 +18,18 @@
 ////////////////////////////////////////////////////////////////////////////////
 package org.apache.royale.jewel.beads.controls.datefield
 {
-    import org.apache.royale.core.DispatcherBead;
-    import org.apache.royale.core.IStrand;
-    import org.apache.royale.events.Event;
-    import org.apache.royale.events.IEventDispatcher;
-    import org.apache.royale.jewel.DateChooser;
-    import org.apache.royale.jewel.beads.controls.datechooser.DateChooserDateRangeRestriction;
-    import org.apache.royale.jewel.beads.views.DateFieldView;
-													
+	import org.apache.royale.core.DispatcherBead;
+	import org.apache.royale.core.IStrand;
+	import org.apache.royale.events.Event;
+	import org.apache.royale.events.IEventDispatcher;
+	import org.apache.royale.jewel.DateChooser;
+	import org.apache.royale.jewel.beads.controls.datechooser.DateChooserDateRangeRestriction;
+	import org.apache.royale.jewel.beads.views.DateFieldView;
+
 	/**
 	 *  Disable dates which are outside restriction provided by minDate and maxDate properties
 	 *  in DateField component
-     * 
+	 * 
 	 *  @langversion 3.0
 	 *  @playerversion Flash 10.2
 	 *  @playerversion AIR 2.6
@@ -37,7 +37,7 @@ package org.apache.royale.jewel.beads.controls.datefield
 	 */
 	public class DateFieldDateRangeRestriction extends DispatcherBead
 	{
-        /**
+		/**
 		 *  constructor.
 		 *
 		 *  @langversion 3.0
@@ -48,16 +48,16 @@ package org.apache.royale.jewel.beads.controls.datefield
 		public function DateFieldDateRangeRestriction()
 		{
 		}
-		
+
 		private var _minDate:Date;
-        /**
-         *  The minimun date
-         *
-         *  @langversion 3.0
-         *  @playerversion Flash 10.2
-         *  @playerversion AIR 2.6
-         *  @productversion Royale 0.9.8
-         */
+		/**
+		 *  The minimun date
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10.2
+		 *  @playerversion AIR 2.6
+		 *  @productversion Royale 0.9.8
+		 */
 		[Bindable]
 		public function get minDate():Date
 		{
@@ -71,16 +71,16 @@ package org.apache.royale.jewel.beads.controls.datefield
 				setUpDateRangeRestriction();
 			}
 		}
-		
+
 		private var _maxDate:Date;
-        /**
-         *  The maximun date
-         *
-         *  @langversion 3.0
-         *  @playerversion Flash 10.2
-         *  @playerversion AIR 2.6
-         *  @productversion Royale 0.9.8
-         */
+		/**
+		 *  The maximun date
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10.2
+		 *  @playerversion AIR 2.6
+		 *  @productversion Royale 0.9.8
+		 */
 		[Bindable]
 		public function get maxDate():Date
 		{
@@ -94,7 +94,7 @@ package org.apache.royale.jewel.beads.controls.datefield
 				setUpDateRangeRestriction();
 			}
 		}
-		
+
 		/**
 		 *  @copy org.apache.royale.core.IBead#strand
 		 *  
@@ -112,11 +112,11 @@ package org.apache.royale.jewel.beads.controls.datefield
 
 		private var view:DateFieldView;
 		private var dataRangeRestriction:DateChooserDateRangeRestriction;
-		
+
 		private function handleDateFieldInitComplete(event:Event):void
 		{
 			(_strand as IEventDispatcher).removeEventListener("initComplete", handleDateFieldInitComplete);
-            (_strand as IEventDispatcher).addEventListener('popUpOpened', popUpOpenedHandler, false);
+			(_strand as IEventDispatcher).addEventListener('popUpOpened', popUpOpenedHandler, false);
 			
 			view = _strand.getBeadByType(DateFieldView) as DateFieldView;
 		}
@@ -129,17 +129,15 @@ package org.apache.royale.jewel.beads.controls.datefield
 			dataRangeRestriction.minDate = minDate;
 			dataRangeRestriction.maxDate = maxDate;
 		}
-		
+
 		protected function popUpOpenedHandler():void
 		{
-            if (!minDate || !maxDate) return;
-			
-            setUpDateRangeRestriction();
+			setUpDateRangeRestriction();
 
 			var dateChooser:DateChooser = view.popUp as DateChooser;
 			dateChooser.addBead(dataRangeRestriction);
 
 			dataRangeRestriction.setUpBead();
 		}
-    }
+	}
 }


### PR DESCRIPTION
The current date range restriction bead is based on time instead of calendar days and doesn't work for each of the date chooser's other views (day, month, and year).

This change disregards time as that doesn't allow the ranges to be inclusive and adds filtering for each view.

The current restriction bead will not allow you to choose the same day for a start and end range. This resolves that issue.