### PR TITLE
Add support for function instances to getQualifiedClassName().

### DIFF
--- a/frameworks/projects/Reflection/src/main/royale/org/apache/royale/reflection/getQualifiedClassName.as
+++ b/frameworks/projects/Reflection/src/main/royale/org/apache/royale/reflection/getQualifiedClassName.as
@@ -38,8 +38,11 @@ COMPILE::JS{
 	{
         COMPILE::SWF
         {
+            var s:String = flash.utils.getQualifiedClassName(value);
+            if (s === "builtin.as$0::MethodClosure")
+                return s;  // don't replace ::
             //normalize for Vector:
-            return flash.utils.getQualifiedClassName(value).replace('__AS3__.vec::','').replace('::','.');
+            return s.replace('__AS3__.vec::','').replace('::','.');
         }
         COMPILE::JS
         {
@@ -87,6 +90,8 @@ COMPILE::JS{
                     }
                 }
                 if (!classInfo) {
+                    if (defName === "function") return "builtin.as$0::MethodClosure";
+
                     //fallback
                     return "Object";
                 }

--- a/frameworks/projects/Reflection/src/test/royale/flexUnitTests/reflection/ReflectionTesterNativeTypes.as
+++ b/frameworks/projects/Reflection/src/test/royale/flexUnitTests/reflection/ReflectionTesterNativeTypes.as
@@ -244,6 +244,30 @@ package flexUnitTests.reflection
             assertEquals( def.name, "Vector.<uint>", "Unexpected type name");
         
         }
+
+
+        [Test]
+        public function testFunctionClass():void
+        {
+//            assertEquals( getQualifiedClassName(Function), "Function", "Unexpected type name");
+//            assertEquals( getDefinitionByName("Function"), Function, "Unexpected type");
+            
+//            var def:TypeDefinition = describeType(Function);
+//            assertEquals( def.name, "Function", "Unexpected type name");
+        
+        }
+    
+    
+        [Test]
+        public function testFunctionInstance():void
+        {
+            var inst:Function = testFunctionClass;
+            assertEquals( getQualifiedClassName(inst), "builtin.as$0::MethodClosure", "Unexpected type name");
+    
+//            var def:TypeDefinition = describeType(inst);
+//            assertEquals( def.name, "builtin.as$0::MethodClosure", "Unexpected type name");
+        
+        }
         
     }
 }


### PR DESCRIPTION
Added support for function instances passed into getQualifiedClassName().  For example, getQualifiedClassName(getQualifiedClassName).

Did not add support for calling with "Function", i.e. literally calling getQualifiedClassName(Function).  In that case, it's supposed to return string "Function", but no idea how to differentiate between function instances and "Function" (both have type "function" internally, like so many other things) in JS side.

Also added some tests in Reflection for this, but commented out ones that won't work right now.

getQualifiedClassName(myfunc) returns a string with "::" in it, so I made special exception for that on the SWF side.  Currently, due to commit 6cce56f26414653c33cc79cc772b066400db3e5b, on the SWF side, it generally replaces "::" with ".".  I assume it's to not have to add code for making the JS side match.  Should this getQualifiedClassName() be different from Flex in that respect?
