### PR TITLE
Several Container fixes for SWF target (not related to PR 1041)

### DIFF
--- a/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/supportClasses/Viewport.as
+++ b/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/supportClasses/Viewport.as
@@ -87,6 +87,9 @@ package org.apache.royale.html.supportClasses
 			{
 				contentArea = new c() as UIBase;
 			}
+
+			if (!contentArea)
+				contentArea = value as UIBase;
 		}
 		
 		/**

--- a/frameworks/projects/Core/src/main/royale/org/apache/royale/core/LayoutBase.as
+++ b/frameworks/projects/Core/src/main/royale/org/apache/royale/core/LayoutBase.as
@@ -310,7 +310,6 @@ package org.apache.royale.core
 		 *  @playerversion Flash 10.2
 		 *  @playerversion AIR 2.6
 		 *  @productversion Royale 0.8
-		 * @royaleignorecoercion org.apache.royale.core.ILayoutParent
 		 * @royaleignorecoercion org.apache.royale.events.IEventDispatcher
 		 */
 		public function performLayout():void

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/core/FlexCSSStyles.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/core/FlexCSSStyles.as
@@ -64,5 +64,7 @@ public class FlexCSSStyles extends AllCSSStyles
     public var horizontalGap:*;
     public var verticalGap:*;
 
+    // Spark styles
+    public var skinClass:*;
 }
 }

--- a/frameworks/projects/SparkRoyale/src/main/resources/defaults.css
+++ b/frameworks/projects/SparkRoyale/src/main/resources/defaults.css
@@ -315,7 +315,6 @@ TitleWindow
 		iBackgroundBead: ClassReference("org.apache.royale.html.beads.SolidBackgroundBead");
 		iBorderBead: ClassReference('org.apache.royale.html.beads.SingleLineBorderBead');
 		iBorderModel: ClassReference('org.apache.royale.html.beads.models.SingleLineBorderModel');
-		IContentView: ClassReference("org.apache.royale.html.supportClasses.DataGroup");
 		font-size: 11px;
 		font-family: Arial;
 	}

--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/SkinnableContainer.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/SkinnableContainer.as
@@ -51,6 +51,7 @@ import org.apache.royale.core.IChild;
 import org.apache.royale.core.IContainer;
 import org.apache.royale.core.IContainerBaseStrandChildrenHost;
 import org.apache.royale.core.ILayoutHost;
+import org.apache.royale.core.ILayoutParent;
 import org.apache.royale.core.IParent;
 import org.apache.royale.core.ValuesManager;
 import org.apache.royale.events.ValueEvent;
@@ -367,7 +368,7 @@ include "../styles/metadata/SelectionFormatTextStyles.as"
  *  @playerversion AIR 1.5
  *  @productversion Royale 0.9.4
  */
-public class SkinnableContainer extends SkinnableContainerBase implements IContainer, IContainerBaseStrandChildrenHost
+public class SkinnableContainer extends SkinnableContainerBase implements IContainer, IContainerBaseStrandChildrenHost, ILayoutParent
 {// SkinnableContainerBase 
  //    implements IDeferredContentOwner, IVisualElementContainer
    // include "../core/Version.as";

--- a/frameworks/projects/SparkRoyale/src/main/royale/spark/components/SkinnableDataContainer.as
+++ b/frameworks/projects/SparkRoyale/src/main/royale/spark/components/SkinnableDataContainer.as
@@ -51,6 +51,7 @@ import org.apache.royale.core.IBeadLayout;
 import org.apache.royale.core.IBeadView;
 import org.apache.royale.core.IChild;
 import org.apache.royale.core.ILayoutHost;
+import org.apache.royale.core.ILayoutParent;
 import org.apache.royale.core.IParent;
 import org.apache.royale.core.ItemRendererClassFactory;
 import org.apache.royale.core.ValuesManager;
@@ -229,7 +230,7 @@ import org.apache.royale.utils.loadBeadFromValuesManager;
  *  @playerversion AIR 1.5
  *  @productversion Royale 0.9.8
  */
-public class SkinnableDataContainer extends SkinnableContainerBase implements IItemRendererProvider, IStrandWithPresentationModel
+public class SkinnableDataContainer extends SkinnableContainerBase implements IItemRendererProvider, IStrandWithPresentationModel, ILayoutParent
 { //implements IItemRendererOwner
     //include "../core/Version.as";
     


### PR DESCRIPTION
Several Container fixes for SWF target (not related to PR 1041).  These are for issues that predate PR 1041.

That is, after the fix for PR 1041, this is a different set of fixes that are needed to run Containers under SWF.

NOTE:  This may expose (legitimate) problems in some Containers outside of Spark that are using Core LayoutBase but not marked as implementing ILayoutParent.  In that case, there will be an exception in LayoutBase.performLayout(), in either JS or SWF, for the host (Container).