### PR TITLE
Fix exception in SWF target with recent changes in ContentView.

### DIFF
--- a/frameworks/projects/Basic/src/main/royale/org/apache/royale/core/ContainerBase.as
+++ b/frameworks/projects/Basic/src/main/royale/org/apache/royale/core/ContainerBase.as
@@ -107,6 +107,11 @@ package org.apache.royale.core
 		override public function addElement(c:IChild, dispatchEvent:Boolean = true):void
 		{
 			var contentView:IParent = getLayoutHost().contentView as IParent;
+			if (c == contentView)
+			{
+				super.addElement(c);
+				return;
+			}
 			contentView.addElement(c, dispatchEvent);
             if (dispatchEvent)
                 sendEvent(this,new ValueEvent("childrenAdded", c));

--- a/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/supportClasses/container/ContainerBase.as
+++ b/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/supportClasses/container/ContainerBase.as
@@ -82,6 +82,11 @@ package org.apache.royale.jewel.supportClasses.container
 		override public function addElement(c:IChild, dispatchEvent:Boolean = true):void
 		{
 			var contentView:IParent = getLayoutHost().contentView as IParent;
+			if (c == contentView)
+			{
+				super.addElement(c);
+				return;
+			}
 			contentView.addElement(c, dispatchEvent);
             if (dispatchEvent)
                 this.dispatchEvent(new ValueEvent("childrenAdded", c));

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/core/Container.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/core/Container.as
@@ -1378,6 +1378,11 @@ public class Container extends UIComponent
 	override public function addElement(c:IChild, dispatchEvent:Boolean = true):void
 	{
 		var contentView:IParent = getLayoutHost().contentView as IParent;
+		if (c == contentView)
+		{
+			super.addElement(c);
+			return;
+		}
 		contentView.addElement(c, dispatchEvent);
 		if (dispatchEvent)
 			this.dispatchEvent(new ValueEvent("childrenAdded", c));


### PR DESCRIPTION
Fixes issue in SWF target caused by PR #1041.

Basically, any Container with an addElement() that proxies to contentView.addElement() needs to check that the child is not the contentView.  This comes about through ContainerView.  (If it is addElement(contentView), then it needs to call super.addElement() instead of proxying the call.)

[Legacy was that addElement(contentView) happened only on JS side, and the addElement() proxying was usually only on the SWF side (except in SkinnableContainer), so they didn't interact.  Recent changes made addElement(contentView) happen on the SWF side, too, so now they interacted.]

ADDED CHECK

frameworks\projects\Basic\src\main\royale\org\apache\royale\core\ContainerBase.as
frameworks\projects\MXRoyale\src\main\royale\mx\core\Container.as
frameworks\projects\Jewel\src\main\royale\org\apache\royale\jewel\supportClasses\container\ContainerBase.as

CHECK NOT NEEDED

frameworks\projects\SparkRoyale\src\main\royale\spark\components\SkinnableContainer.as
	- Already has the check.

frameworks\projects\Basic\src\main\royale\org\apache\royale\svg\GraphicContainer.as
	- Doesn't have contentView.

frameworks\projects\Core\src\main\royale\org\apache\royale\core\ContainerBaseStrandChildren.as
	- Doesn't have contentView.
