### PR TITLE
Jewel VirtualComboBox only recognises itemRenderers assigned via className

### DIFF
--- a/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/views/VirtualComboBoxPopUpView.as
+++ b/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/views/VirtualComboBoxPopUpView.as
@@ -23,6 +23,7 @@ package org.apache.royale.jewel.beads.views
     import org.apache.royale.jewel.List;
     import org.apache.royale.jewel.VirtualList;
     import org.apache.royale.jewel.beads.models.IJewelSelectionModel;
+    import org.apache.royale.jewel.supportClasses.combobox.VirtualComboBoxPopUp;
 
     /**
 	 *  The VirtualComboBoxPopUpView class is a view bead for the VirtualComboBoxPopUp.
@@ -58,6 +59,11 @@ package org.apache.royale.jewel.beads.views
                 _list = new VirtualList();
 				_list.addEventListener("beadsAdded", beadsAddedHandler);
             }
+
+			if((_strand as VirtualComboBoxPopUp).itemRenderer)
+			{
+				_list.itemRenderer = (_strand as VirtualComboBoxPopUp).itemRenderer;
+			}
             return _list;
         }
     }

--- a/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/views/VirtualComboBoxPopUpView.as
+++ b/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/views/VirtualComboBoxPopUpView.as
@@ -50,7 +50,14 @@ package org.apache.royale.jewel.beads.views
 
 		override public function set strand(value:IStrand):void{
 			super.strand = value;
+			
+			var virtualComboBoxPopup:VirtualComboBoxPopUp = _strand as VirtualComboBoxPopUp;
+			if (virtualComboBoxPopup && virtualComboBoxPopup.itemRenderer)
+			{
+				list.itemRenderer = virtualComboBoxPopup.itemRenderer;
+			}
 			(list.model as IJewelSelectionModel).dispatchEvent(new Event("popUpCreated"));
+
 		}
         
         override public function get list():List
@@ -60,10 +67,6 @@ package org.apache.royale.jewel.beads.views
 				_list.addEventListener("beadsAdded", beadsAddedHandler);
             }
 
-			if((_strand as VirtualComboBoxPopUp).itemRenderer)
-			{
-				_list.itemRenderer = (_strand as VirtualComboBoxPopUp).itemRenderer;
-			}
             return _list;
         }
     }


### PR DESCRIPTION
Those set through property "itemRenderer" in the mxml tag are not recognised.

It can be checked in the TDJ. If we change the mapping of the ItemRenderer in the VirtualComboBox of the VirtualListsPlayGround.mxml view from className to itemRenderer tag.

This is how it is now:

![image](https://user-images.githubusercontent.com/55754195/135001896-70f67cce-f19f-4f9c-a1d2-4404c3095110.png)
![image](https://user-images.githubusercontent.com/55754195/135001967-1f3672d5-7f71-455c-b8bd-5a62bab33d35.png)

The result is:

![image](https://user-images.githubusercontent.com/55754195/135002290-333cdc38-6b27-42f0-9086-ff326993133e.png)


If we change it to:
![image](https://user-images.githubusercontent.com/55754195/135001722-50ec5f5c-edf6-4b12-abcd-dc451f67da79.png)

The result is:
![image](https://user-images.githubusercontent.com/55754195/135002225-c467b11a-fc9f-4d5d-bf1d-4c93a42e32e3.png)

I have located the problem in VirtualComboBoxPopUpView by overriding the function "get list". When creating the List associated to the dropdown/popup the itemRenderer assigned to the VirtualCombobox must be mapped to it.
(I have replicated the same function of ComboBoxPopUpView)

Are the modifications correct?

Thx.