### PR TITLE
Adding exemple on how to use locales and setting it by URL parameter

### DIFF
--- a/examples/royale/LocalesExemple/LocalesExemple.as3proj
+++ b/examples/royale/LocalesExemple/LocalesExemple.as3proj
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<project>
+  <output>
+    <movie version="11"/>
+    <movie disabled="False"/>
+    <movie height="600"/>
+    <movie fps="60"/>
+    <movie background="#FFFFFF"/>
+    <movie path="bin-debug/LocalesExemple.swf"/>
+    <movie width="800"/>
+    <movie input=""/>
+  </output>
+  &lt;!-- Other classes to be compiled into your SWF --&gt;
+  <classpaths>
+    <class path="src/main/royale"/>
+  </classpaths>
+  <moonshineResourcePaths></moonshineResourcePaths>
+  <build>
+    <option customSDK=""/>
+    <option strict="True"/>
+    <option accessible="False"/>
+    <option useNetwork="True"/>
+    <option allowSourcePathOverlap="False"/>
+    <option useResourceBundleMetadata="True"/>
+    <option benchmark="False"/>
+    <option warnings="True"/>
+    <option additional=""/>
+    <option es="False"/>
+    <option locale=""/>
+    <option loadConfig=""/>
+    <option linkReport=""/>
+    <option optimize="False"/>
+    <option verboseStackTraces="False"/>
+    <option staticLinkRSL="False"/>
+    <option showBindingWarnings="True"/>
+    <option compilerConstants=""/>
+    <option showDeprecationWarnings="True"/>
+    <option antBuildPath="build/build.xml"/>
+    <option showActionScriptWarnings="True"/>
+    <option showUnusedTypeSelectorWarnings="True"/>
+  </build>
+  <includeLibraries></includeLibraries>
+  <libraryPaths></libraryPaths>
+  <externalLibraryPaths></externalLibraryPaths>
+  <rslPaths></rslPaths>
+  <intrinsics></intrinsics>
+  <library></library>
+  <compileTargets>
+    <compile path="src/main/royale/LocalesExemple.mxml"/>
+  </compileTargets>
+  <hiddenPaths></hiddenPaths>
+  <preBuildCommand>null</preBuildCommand>
+  <postBuildCommand alwaysRun="False">null</postBuildCommand>
+  <options>
+    <option defaultBuildTargets=""/>
+    <option testMovie=""/>
+    <option testMovieCommand=""/>
+    <option showHiddenPaths="False"/>
+  </options>
+  <moonshineRunCustomization>
+    <option deviceSimulator="null"/>
+    <option targetPlatform="2"/>
+    <option projectType="2"/>
+    <option launchMethod="Simulator"/>
+    <option urlToLaunch=""/>
+    <deviceSimulator>null</deviceSimulator>
+    <certAndroid>null</certAndroid>
+    <certIos>null</certIos>
+    <certIosProvisioning>null</certIosProvisioning>
+  </moonshineRunCustomization>
+</project>

--- a/examples/royale/LocalesExemple/asconfig.json
+++ b/examples/royale/LocalesExemple/asconfig.json
@@ -1,0 +1,32 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+{
+    "config": "royale",
+    "compilerOptions": {
+        "debug": false,
+        "targets": ["JSRoyale"],
+        "source-map": true,
+        "js-library-path": ["${royalelib}/js/libs/MXRoyaleJS.swc"]
+    },
+    "additionalOptions": "-remove-circulars -js-output-optimization=skipAsCoercions",
+    "files":
+    [
+        "src/main/royale/LocalesExemple.mxml"
+    ]
+}

--- a/examples/royale/LocalesExemple/build.xml
+++ b/examples/royale/LocalesExemple/build.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+
+
+<project name="LocalesExemple" default="main" basedir=".">
+    <property name="ROYALE_HOME" location="../../.."/>
+    <property name="example" value="LocalesExemple" />
+    
+    <property file="${ROYALE_HOME}/env.properties"/>
+    <property environment="env"/>
+    <property file="${ROYALE_HOME}/build.properties"/>
+    <property name="ROYALE_HOME" value="${ROYALE_HOME}"/>
+
+    <include file="${basedir}/../../build_example.xml" />
+    
+    <target name="main" depends="clean,build_example.compile" description="Clean build of ${example}">
+    </target>
+    
+    <target name="clean">
+        <delete dir="${basedir}/bin" failonerror="false" />
+        <delete dir="${basedir}/bin-debug" failonerror="false" />
+        <delete dir="${basedir}/bin-release" failonerror="false" />
+        <delete dir="${basedir}/target" failonerror="false" />
+    </target>
+
+    <target name="examine" depends="build_example.get.browser">
+        <property name="which" value="debug" />
+        <echo message="Make sure label appears."/>
+        <exec executable="${browser}" dir="${basedir}/bin-${which}" failonerror="true">
+            <arg value="${basedir}/bin-${which}/${example}.html"/>
+        </exec>
+        <exec executable="${browser}" dir="${basedir}/bin/js-${which}" failonerror="true">
+            <arg value="${basedir}/bin/js-${which}/index.html"/>
+        </exec>
+    </target>
+
+</project>

--- a/examples/royale/LocalesExemple/pom.xml
+++ b/examples/royale/LocalesExemple/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.royale.examples</groupId>
+    <artifactId>examples-royale</artifactId>
+    <version>0.9.10-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>LocalesExemple</artifactId>
+  <version>0.9.10-SNAPSHOT</version>
+  <packaging>swf</packaging>
+
+  <name>Apache Royale: Examples: Royale: LocalesExemple</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.royale.compiler</groupId>
+        <artifactId>royale-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <mainClass>LocalesExemple.mxml</mainClass>
+          <targets>${royale.targets}</targets>
+          <additionalCompilerOptions>
+            -js-complex-implicit-coercions=false;
+            -js-vector-index-checks=false;
+            -js-resolve-uncertain=false;
+          </additionalCompilerOptions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.royale.framework</groupId>
+      <artifactId>Basic</artifactId>
+      <version>0.9.10-SNAPSHOT</version>
+      <type>swc</type>
+      <classifier>js</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.royale.framework</groupId>
+      <artifactId>BasicTheme</artifactId>
+      <version>0.9.10-SNAPSHOT</version>
+      <type>swc</type>
+      <scope>theme</scope>
+      <classifier>js</classifier>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>option-with-swf</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.royale.framework</groupId>
+          <artifactId>Basic</artifactId>
+          <version>0.9.10-SNAPSHOT</version>
+          <type>swc</type>
+          <classifier>swf</classifier>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
+<properties /></project>

--- a/examples/royale/LocalesExemple/src/main/royale/LocalesExemple.mxml
+++ b/examples/royale/LocalesExemple/src/main/royale/LocalesExemple.mxml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<js:Application xmlns:fx="http://ns.adobe.com/mxml/2009" 
+                xmlns:js="library://ns.apache.org/royale/basic" 
+                applicationComplete="onApplicationComplete()"
+                initialize="onInitialize()">
+
+
+   	<fx:Script>
+		<![CDATA[
+
+
+			[Embed("locale/en_US/AppMessages.properties", mimeType="text/plain")]
+			public var en_USAppMessages:String;
+			[Embed("locale/fr_FR/AppMessages.properties", mimeType="text/plain")]
+			public var fr_FRAppMessages:String;
+
+
+   			public function onInitialize():void {
+                   
+                resourceManager.bundles = [en_USAppMessages,fr_FRAppMessages];
+                
+
+                // Select locale from URL like http://www.mysite.com/?locale=fr_FR
+                var locale:String  =  parameters.getValue('locale');
+				switch (locale){
+                    case 'en_US': 
+                    case 'fr_FR': 
+                        resourceManager.localeChain = locale;
+                    break;
+
+                    default : 
+                        //Fallback
+                        resourceManager.localeChain = "en_US";
+                }
+                
+            }
+
+   			public function onApplicationComplete():void {
+                   lbl_hello.text = resourceManager.getValue('AppMessages', 'Hello');
+                   lbl_title.text = resourceManager.getValue('AppMessages', 'Title');
+			}
+		]]>
+	</fx:Script>
+
+    <js:valuesImpl>
+        <js:SimpleCSSValuesImpl />
+    </js:valuesImpl>
+
+    <js:beads>
+        <js:SimpleLocalizedValuesImpl id="resourceManager"  />
+		<js:ApplicationParametersCaseInsensitive id="parameters" />
+    </js:beads>
+
+    <js:initialView>
+        <js:View>
+            <js:Label id="lbl_hello"/>
+            <js:Label id="lbl_title" y="20"/>
+        </js:View>
+    </js:initialView>
+
+</js:Application>

--- a/examples/royale/LocalesExemple/src/main/royale/locale/en_US/AppMessages.properties
+++ b/examples/royale/LocalesExemple/src/main/royale/locale/en_US/AppMessages.properties
@@ -1,0 +1,2 @@
+Title=You are using en_US
+Hello=Hello

--- a/examples/royale/LocalesExemple/src/main/royale/locale/fr_FR/AppMessages.properties
+++ b/examples/royale/LocalesExemple/src/main/royale/locale/fr_FR/AppMessages.properties
@@ -1,0 +1,2 @@
+Title=Vous utilisez fr_FR
+Hello=Bonjour


### PR DESCRIPTION
For multiple language apps, this exemple show how to get url param 'locale', and how to use it with SimpleLocalizedValuesImpl bead.