### PR TITLE
New Jewel IInputAndButtonView interface …

### DIFF
--- a/frameworks/projects/Jewel/src/main/resources/jewel-manifest.xml
+++ b/frameworks/projects/Jewel/src/main/resources/jewel-manifest.xml
@@ -185,11 +185,13 @@
     <component id="BadgeWithMouseClick" class="org.apache.royale.jewel.beads.controls.BadgeWithMouseClick"/>
     <component id="ToolTip" class="org.apache.royale.jewel.beads.controls.ToolTip"/>
     <component id="Disabled" class="org.apache.royale.jewel.beads.controls.Disabled"/>
+    <component id="InputAndButtonControlDisabled" class="org.apache.royale.jewel.beads.controls.InputAndButtonControlDisabled"/>
     <component id="SizeControl" class="org.apache.royale.jewel.beads.controls.SizeControl"/>
     <component id="ResponsiveSize" class="org.apache.royale.jewel.beads.controls.ResponsiveSize"/>
     <component id="TextAlign" class="org.apache.royale.jewel.beads.controls.TextAlign"/>
     <component id="ResponsiveVisibility" class="org.apache.royale.jewel.beads.layouts.ResponsiveVisibility"/>
     <component id="ReadOnly" class="org.apache.royale.jewel.beads.controls.ReadOnly"/>
+    <component id="InputAndButtonControlReadOnly" class="org.apache.royale.jewel.beads.controls.InputAndButtonControlReadOnly"/>
 
     <component id="ResponsiveDrawer" class="org.apache.royale.jewel.beads.controls.drawer.ResponsiveDrawer"/>
 

--- a/frameworks/projects/Jewel/src/main/royale/JewelClasses.as
+++ b/frameworks/projects/Jewel/src/main/royale/JewelClasses.as
@@ -64,6 +64,7 @@ import org.apache.royale.utils.observeElementSize;
         import org.apache.royale.jewel.beads.controllers.WizardController; WizardController;
 
         import org.apache.royale.jewel.beads.views.PopUpView; PopUpView;
+        import org.apache.royale.jewel.beads.views.IInputAndButtonView; IInputAndButtonView;
         import org.apache.royale.jewel.beads.views.ImageView; ImageView;
         import org.apache.royale.jewel.beads.views.SpinnerView; SpinnerView;
         import org.apache.royale.jewel.beads.views.NumericStepperView; NumericStepperView;

--- a/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/controls/InputAndButtonControlDisabled.as
+++ b/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/controls/InputAndButtonControlDisabled.as
@@ -1,0 +1,92 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+package org.apache.royale.jewel.beads.controls
+{
+	COMPILE::JS
+	{
+	import org.apache.royale.core.HTMLElementWrapper;
+	import org.apache.royale.core.UIBase;
+	}
+	import org.apache.royale.core.IUIBase;
+	import org.apache.royale.jewel.beads.controls.Disabled;
+    import org.apache.royale.jewel.beads.views.IInputAndButtonView;
+	
+	/**
+	 *  The InputAndButtonControlDisabled bead class is a generic Disabled bead that can be used to disable a 
+	 *  Jewel control that implements the IInputAndButtonView interface.
+	 *  
+	 *  @langversion 3.0
+	 *  @playerversion Flash 10.2
+	 *  @playerversion AIR 2.6
+	 *  @productversion Royale 0.9.6
+	 */
+	public class InputAndButtonControlDisabled extends Disabled
+	{
+		/**
+		 *  constructor.
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10.2
+		 *  @playerversion AIR 2.6
+		 *  @productversion Royale 0.9.6
+		 */
+		public function InputAndButtonControlDisabled()
+		{
+		}
+
+		COMPILE::JS
+		protected var lastTextInputElementTabVal:String = null;
+		COMPILE::JS
+		protected var lastButtonElementTabVal:String = null;
+
+		override protected function updateHost():void
+		{
+			COMPILE::JS
+			{
+			var view:IInputAndButtonView = (_strand as UIBase).view as IInputAndButtonView;
+
+			if (view) {
+				var pos:HTMLElement = (_strand as IUIBase).positioner;
+				
+				if(!initialized)
+				{
+					initialized = true;
+					lastElementTabVal = (_strand as HTMLElementWrapper).element.getAttribute("tabindex");
+					lastTextInputElementTabVal = view.textinput.element.getAttribute("tabindex");
+					lastButtonElementTabVal = view.button.element.getAttribute("tabindex");
+				}
+				
+                if(disabled) {
+					setDisableAndTabIndex(pos, true);
+					setDisableAndTabIndex(view.textinput.positioner, true);
+					setDisableAndTabIndex(view.textinput.element);
+					setDisableAndTabIndex(view.button.positioner, true);
+					setDisableAndTabIndex(view.button.element);
+				} else {
+					removeDisableAndTabIndex(pos, true);
+					removeDisableAndTabIndex(view.textinput.positioner, true);
+					removeDisableAndTabIndex(view.textinput.element, false, lastTextInputElementTabVal);
+					removeDisableAndTabIndex(view.button.positioner, true);
+					removeDisableAndTabIndex(view.button.element, false, lastButtonElementTabVal);
+				}
+            }
+			}
+		}
+	}
+}

--- a/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/controls/InputAndButtonControlReadOnly.as
+++ b/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/controls/InputAndButtonControlReadOnly.as
@@ -1,0 +1,92 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+package org.apache.royale.jewel.beads.controls
+{
+	COMPILE::JS
+	{
+	import org.apache.royale.core.HTMLElementWrapper;
+	import org.apache.royale.core.UIBase;
+    import org.apache.royale.jewel.beads.views.IInputAndButtonView;
+	}
+	import org.apache.royale.core.IUIBase;
+	import org.apache.royale.jewel.beads.controls.ReadOnly;
+	
+	/**
+	 *  The InputAndButtonControlReadOnly bead class is a generic ReadOnly bead that can be used to lock a 
+	 *  Jewel control that implements the IInputAndButtonView interface.
+	 * 
+	 *  @langversion 3.0
+	 *  @playerversion Flash 10.2
+	 *  @playerversion AIR 2.6
+	 *  @productversion Royale 0.9.6
+	 */
+	public class InputAndButtonControlReadOnly extends ReadOnly
+	{
+		/**
+		 *  constructor.
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10.2
+		 *  @playerversion AIR 2.6
+		 *  @productversion Royale 0.9.9
+		 */
+		public function InputAndButtonControlReadOnly()
+		{
+		}
+
+		COMPILE::JS
+		protected var lastTextInputElementTabVal:String = null;
+		COMPILE::JS
+		protected var lastButtonElementTabVal:String = null;
+
+		override protected function updateHost():void
+		{
+			COMPILE::JS
+			{
+			var view:IInputAndButtonView = (_strand as UIBase).view as IInputAndButtonView;
+
+			if (view) {
+				var pos:HTMLElement = (_strand as IUIBase).positioner;
+				
+				if(!initialized)
+				{
+					initialized = true;
+					lastElementTabVal = (_strand as HTMLElementWrapper).element.getAttribute("tabindex");
+					lastTextInputElementTabVal = view.textinput.element.getAttribute("tabindex");
+					lastButtonElementTabVal = view.button.element.getAttribute("tabindex");
+				}
+				
+                if(readOnly) {
+					setReadOnlyAndTabIndex(pos, true);
+					setReadOnlyAndTabIndex(view.textinput.positioner, true);
+					setReadOnlyAndTabIndex(view.textinput.element);
+					setReadOnlyAndTabIndex(view.button.positioner, true);
+					setReadOnlyAndTabIndex(view.button.element);
+				} else {
+					removeReadOnlyAndTabIndex(pos, true);
+					removeReadOnlyAndTabIndex(view.textinput.positioner, true);
+					removeReadOnlyAndTabIndex(view.textinput.element, false, lastTextInputElementTabVal);
+					removeReadOnlyAndTabIndex(view.button.positioner, true);
+					removeReadOnlyAndTabIndex(view.button.element, false, lastButtonElementTabVal);
+				}
+            }
+			}
+		}
+	}
+}

--- a/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/controls/combobox/ComboBoxDisabled.as
+++ b/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/controls/combobox/ComboBoxDisabled.as
@@ -18,14 +18,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 package org.apache.royale.jewel.beads.controls.combobox
 {
-	COMPILE::JS
-	{
-	import org.apache.royale.core.HTMLElementWrapper;
-	import org.apache.royale.core.UIBase;
-	import org.apache.royale.jewel.beads.views.ComboBoxView;
-	}
-	import org.apache.royale.core.IUIBase;
-	import org.apache.royale.jewel.beads.controls.Disabled;
+	import org.apache.royale.jewel.beads.controls.InputAndButtonControlDisabled;
 	
 	/**
 	 *  The ComboBoxDisabled bead class is a specialty bead that can be used to disable a Jewel ComboBox.
@@ -35,7 +28,7 @@ package org.apache.royale.jewel.beads.controls.combobox
 	 *  @playerversion AIR 2.6
 	 *  @productversion Royale 0.9.6
 	 */
-	public class ComboBoxDisabled extends Disabled
+	public class ComboBoxDisabled extends InputAndButtonControlDisabled
 	{
 		/**
 		 *  constructor.
@@ -49,43 +42,5 @@ package org.apache.royale.jewel.beads.controls.combobox
 		{
 		}
 
-		COMPILE::JS
-		protected var lastTextInputElementTabVal:String = null;
-		COMPILE::JS
-		protected var lastButtonElementTabVal:String = null;
-
-		override protected function updateHost():void
-		{
-			COMPILE::JS
-			{
-			var view:ComboBoxView = (_strand as UIBase).view as ComboBoxView;
-
-			if (view) {
-				var pos:HTMLElement = (_strand as IUIBase).positioner;
-				
-				if(!initialized)
-				{
-					initialized = true;
-					lastElementTabVal = (_strand as HTMLElementWrapper).element.getAttribute("tabindex");
-					lastTextInputElementTabVal = view.textinput.element.getAttribute("tabindex");
-					lastButtonElementTabVal = view.button.element.getAttribute("tabindex");
-				}
-				
-                if(disabled) {
-					setDisableAndTabIndex(pos, true);
-					setDisableAndTabIndex(view.textinput.positioner, true);
-					setDisableAndTabIndex(view.textinput.element);
-					setDisableAndTabIndex(view.button.positioner, true);
-					setDisableAndTabIndex(view.button.element);
-				} else {
-					removeDisableAndTabIndex(pos, true);
-					removeDisableAndTabIndex(view.textinput.positioner, true);
-					removeDisableAndTabIndex(view.textinput.element, false, lastTextInputElementTabVal);
-					removeDisableAndTabIndex(view.button.positioner, true);
-					removeDisableAndTabIndex(view.button.element, false, lastButtonElementTabVal);
-				}
-            }
-			}
-		}
 	}
 }

--- a/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/controls/combobox/ComboBoxReadOnly.as
+++ b/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/controls/combobox/ComboBoxReadOnly.as
@@ -18,14 +18,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 package org.apache.royale.jewel.beads.controls.combobox
 {
-	COMPILE::JS
-	{
-	import org.apache.royale.core.HTMLElementWrapper;
-	import org.apache.royale.core.UIBase;
-	import org.apache.royale.jewel.beads.views.ComboBoxView;
-	}
-	import org.apache.royale.core.IUIBase;
-	import org.apache.royale.jewel.beads.controls.ReadOnly;
+	import org.apache.royale.jewel.beads.controls.InputAndButtonControlReadOnly;
 	
 	/**
 	 *  The ComboBoxReadOnly bead class is a specialty ReadOnly bead that can be used to lock a Jewel ComboBox.
@@ -37,7 +30,7 @@ package org.apache.royale.jewel.beads.controls.combobox
 	 *  @playerversion AIR 2.6
 	 *  @productversion Royale 0.9.6
 	 */
-	public class ComboBoxReadOnly extends ReadOnly
+	public class ComboBoxReadOnly extends InputAndButtonControlReadOnly
 	{
 		/**
 		 *  constructor.
@@ -50,44 +43,6 @@ package org.apache.royale.jewel.beads.controls.combobox
 		public function ComboBoxReadOnly()
 		{
 		}
-
-		COMPILE::JS
-		protected var lastTextInputElementTabVal:String = null;
-		COMPILE::JS
-		protected var lastButtonElementTabVal:String = null;
-
-		override protected function updateHost():void
-		{
-			COMPILE::JS
-			{
-			var view:ComboBoxView = (_strand as UIBase).view as ComboBoxView;
-
-			if (view) {
-				var pos:HTMLElement = (_strand as IUIBase).positioner;
-				
-				if(!initialized)
-				{
-					initialized = true;
-					lastElementTabVal = (_strand as HTMLElementWrapper).element.getAttribute("tabindex");
-					lastTextInputElementTabVal = view.textinput.element.getAttribute("tabindex");
-					lastButtonElementTabVal = view.button.element.getAttribute("tabindex");
-				}
-				
-                if(readOnly) {
-					setReadOnlyAndTabIndex(pos, true);
-					setReadOnlyAndTabIndex(view.textinput.positioner, true);
-					setReadOnlyAndTabIndex(view.textinput.element);
-					setReadOnlyAndTabIndex(view.button.positioner, true);
-					setReadOnlyAndTabIndex(view.button.element);
-				} else {
-					removeReadOnlyAndTabIndex(pos, true);
-					removeReadOnlyAndTabIndex(view.textinput.positioner, true);
-					removeReadOnlyAndTabIndex(view.textinput.element, false, lastTextInputElementTabVal);
-					removeReadOnlyAndTabIndex(view.button.positioner, true);
-					removeReadOnlyAndTabIndex(view.button.element, false, lastButtonElementTabVal);
-				}
-            }
-			}
-		}
+		
 	}
 }

--- a/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/controls/combobox/IComboBoxView.as
+++ b/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/controls/combobox/IComboBoxView.as
@@ -18,7 +18,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 package org.apache.royale.jewel.beads.controls.combobox
 {
-    import org.apache.royale.core.IBeadView;
+    import org.apache.royale.jewel.beads.views.IInputAndButtonView;
     
 	/**
 	 *  The IComboBoxView interface provides the protocol for any bead that
@@ -29,28 +29,8 @@ package org.apache.royale.jewel.beads.controls.combobox
 	 *  @playerversion AIR 2.6
 	 *  @productversion Royale 0.9.4
 	 */
-	public interface IComboBoxView extends IBeadView
-	{
-		/**
-		 *  The sub-component used for the input area of the ComboBox.
-		 *
-		 *  @langversion 3.0
-		 *  @playerversion Flash 10.2
-		 *  @playerversion AIR 2.6
-		 *  @productversion Royale 0.9.4
-		 */
-		function get textinput():Object;
-		
-		/**
-		 *  The sub-component used for the button to activate the pop-up.
-		 *
-		 *  @langversion 3.0
-		 *  @playerversion Flash 10.2
-		 *  @playerversion AIR 2.6
-		 *  @productversion Royale 0.9.4
-		 */
-		function get button():Object;
-		
+	public interface IComboBoxView extends IInputAndButtonView
+	{		
 		/**
 		 *  The component housing the selection list. The main component must be a placeholder
 		 *  that support responsiveness and holds a subcomponent that parents the list or other possible

--- a/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/views/DateFieldView.as
+++ b/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/views/DateFieldView.as
@@ -29,7 +29,7 @@ package org.apache.royale.jewel.beads.views
 	import org.apache.royale.jewel.supportClasses.util.positionInsideBoundingClientRect;
 	}
 	import org.apache.royale.core.BeadViewBase;
-	import org.apache.royale.core.IBeadView;
+	import org.apache.royale.jewel.beads.views.IInputAndButtonView;
 	import org.apache.royale.core.IDateChooserModel;
 	import org.apache.royale.core.IDateFormatter;
 	import org.apache.royale.core.IFormatter;
@@ -63,7 +63,7 @@ package org.apache.royale.jewel.beads.views
 	 *  @playerversion AIR 2.6
 	 *  @productversion Royale 0.9.4
 	 */
-	public class DateFieldView extends BeadViewBase implements IBeadView
+	public class DateFieldView extends BeadViewBase implements IInputAndButtonView
 	{
 		/**
 		 *  constructor.
@@ -88,7 +88,14 @@ package org.apache.royale.jewel.beads.views
 		 *  @playerversion AIR 2.6
 		 *  @productversion Royale 0.9.4
 		 */
-		public function get menuButton():Button
+		public function get button():Object
+		{
+			return _button;
+		}
+		/**
+		 * deprecated
+		 */
+		public function get menuButton():Object
 		{
 			return _button;
 		}
@@ -101,7 +108,14 @@ package org.apache.royale.jewel.beads.views
 		 *  @playerversion AIR 2.6
 		 *  @productversion Royale 0.9.4
 		 */
-		public function get textInput():TextInput
+		public function get textinput():Object
+		{
+			return _textInput;
+		}
+		/**
+		 * deprecated
+		 */
+		public function get textInput():Object
 		{
 			return _textInput;
 		}

--- a/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/views/IInputAndButtonView.as
+++ b/frameworks/projects/Jewel/src/main/royale/org/apache/royale/jewel/beads/views/IInputAndButtonView.as
@@ -16,32 +16,39 @@
 //  limitations under the License.
 //
 ////////////////////////////////////////////////////////////////////////////////
-package org.apache.royale.jewel.beads.controls.datefield
+package org.apache.royale.jewel.beads.views
 {
-	import org.apache.royale.jewel.beads.controls.InputAndButtonControlDisabled;
-
+    import org.apache.royale.core.IBeadView;
+    
 	/**
-	 *  The DateFieldDisabled bead class is a specialty bead that can be used to disable a Jewel DateField control.
-	 *  This disables all the internal native controls.
-	 *
+	 *  The IInputAndButtonView interface provides the protocol for any bead that
+	 *  creates the visual parts for a control containing a input and a button.
+	 *  
 	 *  @langversion 3.0
 	 *  @playerversion Flash 10.2
 	 *  @playerversion AIR 2.6
-	 *  @productversion Royale 0.9.6
+	 *  @productversion Royale 0.9.4
 	 */
-	public class DateFieldDisabled extends InputAndButtonControlDisabled
+	public interface IInputAndButtonView extends IBeadView
 	{
 		/**
-		 *  constructor.
+		 *  The sub-component used for the input area of the Control.
 		 *
 		 *  @langversion 3.0
 		 *  @playerversion Flash 10.2
 		 *  @playerversion AIR 2.6
-		 *  @productversion Royale 0.9.6
+		 *  @productversion Royale 0.9.4
 		 */
-		public function DateFieldDisabled()
-		{
-		}
+		function get textinput():Object;
 		
+		/**
+		 *  The sub-component used for the button to activate the pop-up.
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 10.2
+		 *  @playerversion AIR 2.6
+		 *  @productversion Royale 0.9.4
+		 */
+		function get button():Object;
 	}
 }


### PR DESCRIPTION
…for the views of controls composed by a textinput and a button.

Implemented in Jewel ComboBox and Jewel DateField.

New generic "Disabled" and "ReadOnly" beads for controls implementing the IInputAndButtonView interface.

For compatibility, temporarily, they have been kept:
- ComboBoxDisabled, ComboBoxReadOnly and DateFieldDisabled beads.
- The previous properties "textInput" ('I' uppercase) and menuButton in the DateFieldView bead.