### PR TITLE
Fix case where sortable=false

### DIFF
--- a/frameworks/projects/MXRoyale/src/main/royale/mx/controls/beads/AdvancedDataGridSortBead.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/controls/beads/AdvancedDataGridSortBead.as
@@ -73,7 +73,7 @@ package mx.controls.beads
             var selectedColumn:AdvancedDataGridColumn = adg.columns[adgEvent.columnIndex];
             if(selectedColumn.sortable) {
                	adgEvent.dataField = selectedColumn.dataField;
-    		this.mx_controls_beads_AdvancedDataGridSortBead_adg.dispatchEvent(adgEvent);
+    		adg.dispatchEvent(adgEvent);
             }
 		
 		}

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/controls/beads/AdvancedDataGridSortBead.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/controls/beads/AdvancedDataGridSortBead.as
@@ -19,6 +19,7 @@
 package mx.controls.beads
 {
 	import mx.controls.AdvancedDataGrid;
+	import mx.controls.advancedDataGridClasses.AdvancedDataGridColumn;
 	import mx.controls.beads.DataGridView;
 	import mx.controls.dataGridClasses.DataGridColumn;
 	import mx.events.AdvancedDataGridEvent;
@@ -69,9 +70,9 @@ package mx.controls.beads
 			}
             var adgEvent:AdvancedDataGridEvent = new AdvancedDataGridEvent(AdvancedDataGridEvent.SORT);
             adgEvent.columnIndex = buttonBar.selectedIndex;
-            var selectedColumn = this.mx_controls_beads_AdvancedDataGridSortBead_adg.columns[adgEvent.columnIndex];
+            var selectedColumn:AdvancedDataGridColumn = this.mx_controls_beads_AdvancedDataGridSortBead_adg.columns[adgEvent.columnIndex];
             if(selectedColumn.sortable) {
-               	adgEvent.dataField = org.apache.royale.utils.Language.string(selectedColumn.dataField);
+               	adgEvent.dataField = selectedColumn.dataField;
     		this.mx_controls_beads_AdvancedDataGridSortBead_adg.dispatchEvent(adgEvent);
             }
 		

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/controls/beads/AdvancedDataGridSortBead.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/controls/beads/AdvancedDataGridSortBead.as
@@ -70,7 +70,7 @@ package mx.controls.beads
 			}
             var adgEvent:AdvancedDataGridEvent = new AdvancedDataGridEvent(AdvancedDataGridEvent.SORT);
             adgEvent.columnIndex = buttonBar.selectedIndex;
-            var selectedColumn:AdvancedDataGridColumn = this.mx_controls_beads_AdvancedDataGridSortBead_adg.columns[adgEvent.columnIndex];
+            var selectedColumn:AdvancedDataGridColumn = adg.columns[adgEvent.columnIndex];
             if(selectedColumn.sortable) {
                	adgEvent.dataField = selectedColumn.dataField;
     		this.mx_controls_beads_AdvancedDataGridSortBead_adg.dispatchEvent(adgEvent);

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/controls/beads/AdvancedDataGridSortBead.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/controls/beads/AdvancedDataGridSortBead.as
@@ -69,8 +69,12 @@ package mx.controls.beads
 			}
             var adgEvent:AdvancedDataGridEvent = new AdvancedDataGridEvent(AdvancedDataGridEvent.SORT);
             adgEvent.columnIndex = buttonBar.selectedIndex;
-            adgEvent.dataField = adg.columns[adgEvent.columnIndex].dataField;
-            adg.dispatchEvent(adgEvent);
+            var selectedColumn = this.mx_controls_beads_AdvancedDataGridSortBead_adg.columns[adgEvent.columnIndex];
+            if(selectedColumn.sortable) {
+               	adgEvent.dataField = org.apache.royale.utils.Language.string(selectedColumn.dataField);
+    		this.mx_controls_beads_AdvancedDataGridSortBead_adg.dispatchEvent(adgEvent);
+            }
+		
 		}
 	}
 }


### PR DESCRIPTION
This change fixes the problem where sortable is still possible even though sortable=false is set in the mxml.

Please note that this does not fix the fact that all columns are sortable by default while they shouldn't. Haven't found a fix for that yet.

Let me know if the fix seems correct to you.