### PR TITLE
Improve tooltip display

### DIFF
--- a/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/accessories/ToolTipBead.as
+++ b/frameworks/projects/Basic/src/main/royale/org/apache/royale/html/accessories/ToolTipBead.as
@@ -156,6 +156,10 @@ package org.apache.royale.html.accessories
 			tt.x = pt.x;
 			tt.y = pt.y;
 			host.popUpParent.addElement(tt, false); // don't trigger a layout
+			
+			// Display de tooltip on several rows if too long
+			tt.element.style.maxWidth = "300px";
+			tt.element.style.whiteSpace = "pre-wrap";
 		}
 
 		/**


### PR DESCRIPTION
If the tooltip is very long, it was displayed on one line and sometimes we could not read the end. This change is to display it on several rows.

Old display : 
![image](https://github.com/apache/royale-asjs/assets/23524780/a9096a79-54ba-4987-81f5-201ede4b455f)


New display : 
![image](https://github.com/apache/royale-asjs/assets/23524780/fd676201-9ac3-40da-af35-79200ea8c10e)
