### PR TITLE
Remove call to parent to create the tooltip

### DIFF
--- a/frameworks/projects/MXRoyale/src/main/royale/mx/controls/Button.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/controls/Button.as
@@ -385,8 +385,6 @@ public class Button extends UIComponent implements IDataRenderer, IListItemRende
 	 */
 	override public function set toolTip(value:String):void
 	{
-		super.toolTip = value;
-		
 		_toolTipBead = getBeadByType(ToolTipBead) as ToolTipBead;
 		if (_toolTipBead == null) {
 			_toolTipBead = new ToolTipBead();

--- a/frameworks/projects/MXRoyale/src/main/royale/mx/controls/Button.as
+++ b/frameworks/projects/MXRoyale/src/main/royale/mx/controls/Button.as
@@ -391,6 +391,7 @@ public class Button extends UIComponent implements IDataRenderer, IListItemRende
 			addBead(_toolTipBead);
 		}
 		_toolTipBead.toolTip = value;
+		dispatchEvent(new Event("toolTipChanged"));
 	}
 	
 	override public function get toolTip():String


### PR DESCRIPTION
When setting the tooltip, 2 different tooltip get created :  one when calling the parent, creating a mx.controls.beads.ToolTipBead and one in the method itself, creating a org.apache.royale.html.accessories.ToolTipBead