### PR TITLE
Fix binary uploader

### DIFF
--- a/frameworks/projects/Network/src/main/royale/org/apache/royale/net/BinaryUploader.as
+++ b/frameworks/projects/Network/src/main/royale/org/apache/royale/net/BinaryUploader.as
@@ -574,7 +574,7 @@ COMPILE::SWF
                             url += '?' + _binaryData.data;
                         }
                     } else {
-                        binaryData = _binaryData.data.toString();
+                        binaryData = _binaryData.toString();
                     }
                 }
                 

--- a/frameworks/projects/Network/src/main/royale/org/apache/royale/net/BinaryUploader.as
+++ b/frameworks/projects/Network/src/main/royale/org/apache/royale/net/BinaryUploader.as
@@ -565,18 +565,7 @@ COMPILE::SWF
                 
                 url = _url;
                 
-                var binaryData:String = null;
-                if (_binaryData != null) {
-                    if (_method == HTTPConstants.GET) {
-                        if (url.indexOf('?') != -1) {
-                            url += _binaryData.data;
-                        } else {
-                            url += '?' + _binaryData.data;
-                        }
-                    } else {
-                        binaryData = _binaryData.toString();
-                    }
-                }
+                
                 
                 element.open(_method, _url, true);
                 element.timeout = _timeout;
@@ -595,15 +584,26 @@ COMPILE::SWF
                 }
                 
                 if (_method != HTTPConstants.GET &&
-                    !sawContentType && binaryData) {
+                    !sawContentType && _binaryData) {
                     element.setRequestHeader(
                         HTTPHeader.CONTENT_TYPE, _contentType);
                 }
                 
-                if (binaryData) {
-                    element.setRequestHeader(HTTPHeader.CONTENT_LENGTH, binaryData.length.toString());
-                    element.setRequestHeader(HTTPHeader.CONNECTION, 'close');
-                    element.send(binaryData);
+                if (_binaryData) {
+                    //element.setRequestHeader(HTTPHeader.CONTENT_LENGTH, binaryData.length.toString()); // seem useless and generate error
+                    //element.setRequestHeader(HTTPHeader.CONNECTION, 'close'); // seem useless and generate error
+                    
+                    if (_method == HTTPConstants.GET) {
+                        if (url.indexOf('?') != -1) {
+                            url += _binaryData.toString();
+                        } else {
+                            url += '?' + _binaryData.toString();
+                        }
+                        element.send();
+                    } else {
+                        element.send(_binaryData.array);
+                    }
+                    
                 } else {
                     element.send();
                 }


### PR DESCRIPTION
I just discovered new issue with BinaryUploader .

With the fisrt fix, it can send real datas instead of "[object ArrayBuffer]" .
This is working right with text files, but it's not working right with some bytes. For exemple a file with 0xc0 inside will be wrong encoded by the TextEncoder('utf8').
To solve that as XMLHttpRequest can send typed array (https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Sending_and_Receiving_Binary_Data#sending_typed_arrays_as_binary_data), there is no need to convert to utf8 string,
So sending this :
`element.send(_binaryData.array);`
instead of
`element.send(binaryData);`
will solve this other issue.